### PR TITLE
implement RawConfigFileProvider

### DIFF
--- a/internal/pkg/resourceconfig/resourceconfig_test.go
+++ b/internal/pkg/resourceconfig/resourceconfig_test.go
@@ -67,6 +67,115 @@ func TestKustomizeProvider2(t *testing.T) {
 	assert.Equal(t, len(inv.Current), 1)
 }
 
+/*
+setupRawConfigFiles provides a directory with Kubernetes resources
+that can be used as input to test RawConfigFileProvider.
+The directory created is
+
+f
+├── service.yaml
+├── subdir1
+│   └── service.yaml
+└── subdir2
+    └── service.yaml
+
+ */
+func setupRawConfigFiles(t *testing.T) (string, string) {
+	f, err := ioutil.TempDir("/tmp", "TestConfigProvider")
+	assert.NoError(t, err)
+	err = ioutil.WriteFile(filepath.Join(f, "service.yaml"), []byte(`
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-a
+spec:
+  selector:
+    app: MyApp
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9376
+`), 0644)
+	assert.NoError(t, err)
+	subdir1, err := ioutil.TempDir(f, "subdir")
+	assert.NoError(t, err)
+	subdir2, err := ioutil.TempDir(f, "subdir")
+	assert.NoError(t, err)
+	err = ioutil.WriteFile(filepath.Join(subdir1, "service.yaml"), []byte(`
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-b
+  annotations:
+    kustomize.config.k8s.io/Inventory: ""
+    kustomize.config.k8s.io/InventoryHash: 8mk644dhch
+spec:
+  selector:
+    app: MyApp
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9376
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+ name: cm
+`), 0644)
+	assert.NoError(t, err)
+	err = ioutil.WriteFile(filepath.Join(subdir2, "service.yaml"), []byte(`
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-c
+spec:
+  selector:
+    app: MyApp
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9376
+`), 0644)
+	assert.NoError(t, err)
+	return f, subdir1
+}
+
+func TestRawConfigFileProvider(t *testing.T) {
+	f, subdir := setupRawConfigFiles(t)
+	defer os.RemoveAll(f)
+	cp := wiretest.InitializeRawConfigProvider()
+	b := cp.IsSupported(f)
+	assert.Equal(t, b, true)
+	resources, err := cp.GetConfig(f)
+	assert.NoError(t, err)
+	assert.Equal(t, len(resources), 4)
+	resources, err = cp.GetConfig(filepath.Join(f, "service.yaml"))
+	assert.NoError(t, err)
+	assert.Equal(t, len(resources), 1)
+
+	resource, err := cp.GetPruneConfig(f)
+	assert.NoError(t, err)
+	assert.NotNil(t, resource)
+	resource, err = cp.GetPruneConfig(filepath.Join(f, "service.yaml"))
+	assert.NoError(t, err)
+	assert.Nil(t, resource)
+
+	b = cp.IsSupported(subdir)
+	resources, err = cp.GetConfig(subdir)
+	assert.NoError(t, err)
+	assert.Equal(t, len(resources), 2)
+	resources, err = cp.GetConfig(filepath.Join(subdir, "service.yaml"))
+	assert.NoError(t, err)
+	assert.Equal(t, len(resources), 2)
+
+	resource, err = cp.GetPruneConfig(subdir)
+	assert.NoError(t, err)
+	assert.NotNil(t, resource)
+	resource, err = cp.GetPruneConfig(filepath.Join(subdir, "service.yaml"))
+	assert.NoError(t, err)
+	assert.NotNil(t, resource)
+}
+
 func setupKustomizeWithoutInventory(t *testing.T) string {
 	f, err := ioutil.TempDir("/tmp", "TestApply")
 	assert.NoError(t, err)

--- a/internal/pkg/wirecli/wireconfig/wireconfig.go
+++ b/internal/pkg/wirecli/wireconfig/wireconfig.go
@@ -43,6 +43,12 @@ var ConfigProviderSet = wire.NewSet(
 	NewResourcePruneConfig,
 )
 
+// RawConfigProviderSet defines dependencies for initializing a RawConfigFileProvider
+var RawConfigProviderSet = wire.NewSet(
+	wire.Struct(new(resourceconfig.RawConfigFileProvider), "*"),
+	wire.Bind(new(resourceconfig.ConfigProvider), new(*resourceconfig.RawConfigFileProvider)),
+)
+
 // NewPluginConfig returns a new PluginConfig
 func NewPluginConfig() *types.PluginConfig {
 	pc := plugin.DefaultPluginConfig()

--- a/internal/pkg/wirecli/wiretest/wire.go
+++ b/internal/pkg/wirecli/wiretest/wire.go
@@ -67,6 +67,10 @@ func InitializConfigProvider() resourceconfig.ConfigProvider {
 	panic(wire.Build(wireconfig.ConfigProviderSet))
 }
 
+func InitializeRawConfigProvider() resourceconfig.ConfigProvider {
+	panic(wire.Build(wireconfig.RawConfigProviderSet))
+}
+
 func InitializeKustomization() ([]string, func(), error) {
 	f1, err := ioutil.TempDir("/tmp", "TestApply")
 	if err != nil {

--- a/internal/pkg/wirecli/wiretest/wire_gen.go
+++ b/internal/pkg/wirecli/wiretest/wire_gen.go
@@ -248,6 +248,11 @@ func InitializConfigProvider() resourceconfig.ConfigProvider {
 	return kustomizeProvider
 }
 
+func InitializeRawConfigProvider() resourceconfig.ConfigProvider {
+	rawConfigFileProvider := &resourceconfig.RawConfigFileProvider{}
+	return rawConfigFileProvider
+}
+
 // wire.go:
 
 func InitializeKustomization() ([]string, func(), error) {


### PR DESCRIPTION
add the implementation of `RawConfigFileProvider`.
- When the given path is a file, this provider loads resources from that file
- When the given path is a directory, this provider loads resources from the directory recursively
- The `GetPruneConfig` loads all the resources and returns the one with the inventory annotation

Also added a test to cover
- load resources from a file
- load resources from a directory recursively
- load the inventory resource

TODO: 
So far we have two config providers in this project:
- the kustomize config provider
- the raw config provider
When an argument is given, we need to decide which provider it should use.
This can be checked by the function `IsSupported`.
I'll add the logic to choose the proper config provider in a subsequent PR.