### PR TITLE
add support for declarative deletion

### DIFF
--- a/internal/pkg/apply/apply.go
+++ b/internal/pkg/apply/apply.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cli-experimental/internal/pkg/client"
 	"sigs.k8s.io/cli-experimental/internal/pkg/clik8s"
+	"sigs.k8s.io/cli-experimental/internal/pkg/constants"
 	"sigs.k8s.io/kustomize/pkg/inventory"
 )
 
@@ -67,7 +68,12 @@ func (a *Apply) Do() (Result, error) {
 				fmt.Fprintf(a.Out, "failed to update inventory object %v\n", err)
 			}
 		}
-
+		if presence, ok := annotation[constants.Presence]; ok {
+			if presence == constants.EnsureNoExist {
+				// not applying the resource
+				continue
+			}
+		}
 		err := a.DynamicClient.Apply(context.Background(), u)
 		if err != nil {
 			fmt.Fprintf(a.Out, "failed to apply the object: %s/%s: %v\n", u.GetKind(), u.GetName(), err)

--- a/internal/pkg/apply/apply_test.go
+++ b/internal/pkg/apply/apply_test.go
@@ -15,10 +15,16 @@ package apply_test
 
 import (
 	"bytes"
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/src-d/go-git.v4/plumbing/object"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/cli-experimental/internal/pkg/apply"
 	"sigs.k8s.io/cli-experimental/internal/pkg/clik8s"
 	"sigs.k8s.io/cli-experimental/internal/pkg/wirecli/wiretest"
@@ -58,4 +64,138 @@ func TestApply(t *testing.T) {
 	r, err = a.Do()
 	assert.NoError(t, err)
 	assert.Equal(t, apply.Result{updatedObjects}, r)
+}
+
+func InitializeKustomizationWithPresence() ([]string, func(), error) {
+	f1, err := ioutil.TempDir("/tmp", "TestApply")
+	if err != nil {
+		return nil, nil, err
+	}
+	err = ioutil.WriteFile(filepath.Join(f1, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+- name: test-map
+
+inventory:
+  type: ConfigMap
+  configMap:
+    name: inventory
+    namespace: default
+
+resources:
+- not-apply-service.yaml
+
+namespace: default
+`), 0644)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(f1, "not-apply-service.yaml"), []byte(`
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  annotations:
+    kubectl.kubernetes.io/presence: EnsureDoesNotExist
+spec:
+  selector:
+    app: MyApp
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9376
+`), 0644)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	f2, err := ioutil.TempDir("/tmp", "TestApply")
+	if err != nil {
+		return nil, nil, err
+	}
+	err = ioutil.WriteFile(filepath.Join(f2, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+- name: test-map
+  literals:
+  - foo=bar
+
+inventory:
+  type: ConfigMap
+  configMap:
+    name: inventory
+    namespace: default
+
+resources:
+- not-apply-service.yaml
+
+namespace: default
+`), 0644)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(f2, "not-apply-service.yaml"), []byte(`
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  annotations:
+    kubectl.kubernetes.io/presence: EnsureDoesNotExist
+spec:
+  selector:
+    app: MyApp
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9376
+`), 0644)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return []string{f1, f2}, func() {
+		os.RemoveAll(f1)
+		os.RemoveAll(f2)
+	}, nil
+}
+
+func TestApplyWithPresenceAnnotation(t *testing.T) {
+	buf := new(bytes.Buffer)
+	kp := wiretest.InitializConfigProvider()
+	fs, cleanup, err := InitializeKustomizationWithPresence()
+	defer cleanup()
+	assert.NoError(t, err)
+	assert.Equal(t, len(fs), 2)
+
+	objects, err := kp.GetConfig(fs[0])
+	assert.NoError(t, err)
+
+	a, done, err := wiretest.InitializeApply(objects, &object.Commit{}, buf)
+	defer done()
+
+	serviceList := &unstructured.UnstructuredList{}
+	serviceList.SetGroupVersionKind(schema.GroupVersionKind{
+		Kind:    "ServiceList",
+		Version: "v1",
+	})
+	err = a.DynamicClient.List(context.Background(), serviceList, "default", nil)
+	defaultCount := len(serviceList.Items)
+
+	assert.NoError(t, err)
+	r, err := a.Do()
+	assert.NoError(t, err)
+	assert.Equal(t, apply.Result{objects}, r)
+	err = a.DynamicClient.List(context.Background(), serviceList, "default", nil)
+	assert.Equal(t, len(serviceList.Items), defaultCount)
+
+	updatedObjects, err := kp.GetConfig(fs[1])
+	a.Resources = updatedObjects
+	assert.NoError(t, err)
+	r, err = a.Do()
+	assert.NoError(t, err)
+	assert.Equal(t, apply.Result{updatedObjects}, r)
+	err = a.DynamicClient.List(context.Background(), serviceList, "default", nil)
+	assert.Equal(t, len(serviceList.Items), defaultCount)
 }

--- a/internal/pkg/clik8s/clik8s.go
+++ b/internal/pkg/clik8s/clik8s.go
@@ -35,4 +35,4 @@ type MasterURL string
 type ResourceConfigs []*unstructured.Unstructured
 
 // ResourcePruneConfigs is a collection of Resource Config used for pruning
-type ResourcePruneConfigs *unstructured.Unstructured
+type ResourcePruneConfigs []*unstructured.Unstructured

--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -20,21 +20,21 @@ const (
 	Presence = "kubectl.kubernetes.io/presence"
 
 	// Any resource with the annotation
-	//   kubectl.kubernetes.io/presence: EnsureExist
+	//   kubectl.kubernetes.io/presence: PreventDeletion
 	// will not be pruned or deleted.
 	//
-	// It following effect in each command
+	// It has the following effect in each command
 	// - no effect in apply
 	// - prune skips this resource
 	// - delete skips this resource
 
-	EnsureExist = "EnsureExist"
+	PreventDeletion = "PreventDeletion"
 
 	// Any resource with the annotation
 	//  kubectl.kubernetes.io/presence: EnsureDoesNotExist
 	// Will be deleted or skipped in apply.
 	//
-	// It has following effect in each command
+	// It has the following effect in each command
 	// - the resource is skipped in apply
 	// - the resource is deleted in prune
 	// - the resource is deleted in delete

--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -18,6 +18,25 @@ package constants
 
 const (
 	Presence = "kubectl.kubernetes.io/presence"
+
+	// Any resource with the annotation
+	//   kubectl.kubernetes.io/presence: EnsureExist
+	// will not be pruned or deleted.
+	//
+	// It following effect in each command
+	// - no effect in apply
+	// - prune skips this resource
+	// - delete skips this resource
+
 	EnsureExist = "EnsureExist"
+
+	// Any resource with the annotation
+	//  kubectl.kubernetes.io/presence: EnsureDoesNotExist
+	// Will be deleted or skipped in apply.
+	//
+	// It has following effect in each command
+	// - the resource is skipped in apply
+	// - the resource is deleted in prune
+	// - the resource is deleted in delete
 	EnsureNoExist = "EnsureDoesNotExist"
 )

--- a/internal/pkg/constants/constants.go
+++ b/internal/pkg/constants/constants.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constants
+
+const (
+	Presence = "kubectl.kubernetes.io/presence"
+	EnsureExist = "EnsureExist"
+	EnsureNoExist = "EnsureDoesNotExist"
+)

--- a/internal/pkg/delete/delete_test.go
+++ b/internal/pkg/delete/delete_test.go
@@ -16,6 +16,9 @@ package delete_test
 import (
 	"bytes"
 	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -77,4 +80,133 @@ func TestDelete(t *testing.T) {
 	err = d.DynamicClient.List(context.Background(), cmList, "default", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, len(cmList.Items), 0)
+}
+
+func InitializeKustomizationWithPresence() ([]string, func(), error) {
+	f1, err := ioutil.TempDir("/tmp", "TestApply")
+	if err != nil {
+		return nil, nil, err
+	}
+	err = ioutil.WriteFile(filepath.Join(f1, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+- name: test-map
+
+inventory:
+  type: ConfigMap
+  configMap:
+    name: inventory
+    namespace: default
+
+resources:
+- not-delete-service.yaml
+
+namespace: default
+`), 0644)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(f1, "not-delete-service.yaml"), []byte(`
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  annotations:
+    kubectl.kubernetes.io/presence: EnsureExist
+spec:
+  selector:
+    app: MyApp
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9376
+`), 0644)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	f2, err := ioutil.TempDir("/tmp", "TestApply")
+	if err != nil {
+		return nil, nil, err
+	}
+	err = ioutil.WriteFile(filepath.Join(f2, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+configMapGenerator:
+- name: test-map
+  literals:
+  - foo=bar
+
+inventory:
+  type: ConfigMap
+  configMap:
+    name: inventory
+    namespace: default
+
+namespace: default
+`), 0644)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return []string{f1, f2}, func() {
+		os.RemoveAll(f1)
+		os.RemoveAll(f2)
+	}, nil
+}
+
+func TestDeleteWithPresence(t *testing.T) {
+	buf := new(bytes.Buffer)
+	kp := wiretest.InitializConfigProvider()
+	fs, cleanup, err := InitializeKustomizationWithPresence()
+	defer cleanup()
+	assert.NoError(t, err)
+	assert.Equal(t, len(fs), 2)
+
+	objects, err := kp.GetConfig(fs[0])
+	assert.NoError(t, err)
+	a, donea, err := wiretest.InitializeApply(objects, &object.Commit{}, buf)
+	assert.NoError(t, err)
+	defer donea()
+
+	serviceList := &unstructured.UnstructuredList{}
+	serviceList.SetGroupVersionKind(schema.GroupVersionKind{
+		Kind:    "ServiceList",
+		Version: "v1",
+	})
+	err = a.DynamicClient.List(context.Background(), serviceList, "default", nil)
+	defaultCount := len(serviceList.Items)
+	
+	_, err = a.Do()
+	assert.NoError(t, err)
+	updatedObjects, err := kp.GetConfig(fs[1])
+	assert.NoError(t, err)
+	a.Resources = updatedObjects
+	_, err = a.Do()
+	assert.NoError(t, err)
+
+	cmList := &unstructured.UnstructuredList{}
+	cmList.SetGroupVersionKind(schema.GroupVersionKind{
+		Kind:    "ConfigMapList",
+		Version: "v1",
+	})
+	err = a.DynamicClient.List(context.Background(), cmList, "default", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(cmList.Items), 3)
+
+	d, doned, err := wiretest.InitializeDelete(updatedObjects, &object.Commit{}, buf)
+	defer doned()
+	assert.NoError(t, err)
+	d.DynamicClient = a.DynamicClient
+	_, err = d.Do()
+	assert.NoError(t, err)
+
+	err = d.DynamicClient.List(context.Background(), cmList, "default", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(cmList.Items), 0)
+
+
+	err = a.DynamicClient.List(context.Background(), serviceList, "default", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(serviceList.Items), defaultCount + 1)
 }

--- a/internal/pkg/delete/delete_test.go
+++ b/internal/pkg/delete/delete_test.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sigs.k8s.io/cli-experimental/internal/pkg/util"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -113,7 +114,7 @@ kind: Service
 metadata:
   name: my-service
   annotations:
-    kubectl.kubernetes.io/presence: EnsureExist
+    kubectl.kubernetes.io/presence: PreventDeletion
 spec:
   selector:
     app: MyApp
@@ -155,6 +156,29 @@ namespace: default
 	}, nil
 }
 
+/* TestDeleteWithPresence verifies that Delete doesn't
+   delete resources with PreventDeletion annotation.
+   It takes the following steps
+   1. create a Kustomization with
+         a ConfigMapGenerator
+         a Service with the annotation PreventDeletion
+         an inventory ConfigMap
+   2. apply the kustomization
+   3. confirm that there are
+         2 ConfigMaps
+         1 Service
+   3. remove the service resource from the Kustomization
+      Update the ConfigmapGeneraotr, which will generate
+      a ConfigMap with a different name
+   4. apply the kustomization again
+   5. confirm that the Service object is not deleted. There are
+         3 ConfigMaps
+         1 Service
+   6. run delete on the updated kustomization
+   7. confirm that
+         3 ConfigMaps are deleted
+         1 Service still exists
+*/
 func TestDeleteWithPresence(t *testing.T) {
 	buf := new(bytes.Buffer)
 	kp := wiretest.InitializConfigProvider()
@@ -163,50 +187,339 @@ func TestDeleteWithPresence(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(fs), 2)
 
+	// Setup the first kustomization
+	// Confirm that it contains a Service
+	// with the Annotation PreventDeletion
 	objects, err := kp.GetConfig(fs[0])
 	assert.NoError(t, err)
-	a, donea, err := wiretest.InitializeApply(objects, &object.Commit{}, buf)
-	assert.NoError(t, err)
-	defer donea()
+	service := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata": map[string]interface{}{
+				"name":      "my-service",
+				"namespace": "default",
+				"annotations": map[string]interface{}{
+					"kubectl.kubernetes.io/presence": "PreventDeletion",
+				},
+			},
+			"spec": map[string]interface{}{
+				"ports": []interface{}{
+					map[string]interface{}{
+						"port":       int64(80),
+						"protocol":   "TCP",
+						"targetPort": int64(9376)},
+				},
+				"selector": map[string]interface{}{"app": "MyApp"},
+			},
+		},
+	}
+	assert.Contains(t, objects, service)
 
-	serviceList := &unstructured.UnstructuredList{}
-	serviceList.SetGroupVersionKind(schema.GroupVersionKind{
-		Kind:    "ServiceList",
-		Version: "v1",
-	})
-	err = a.DynamicClient.List(context.Background(), serviceList, "default", nil)
-	defaultCount := len(serviceList.Items)
-	
-	_, err = a.Do()
-	assert.NoError(t, err)
-	updatedObjects, err := kp.GetConfig(fs[1])
-	assert.NoError(t, err)
-	a.Resources = updatedObjects
-	_, err = a.Do()
-	assert.NoError(t, err)
-
+	// setup the ConfigMap list and Service list
+	// used for confirmation
 	cmList := &unstructured.UnstructuredList{}
 	cmList.SetGroupVersionKind(schema.GroupVersionKind{
 		Kind:    "ConfigMapList",
 		Version: "v1",
 	})
+	serviceList := &unstructured.UnstructuredList{}
+	serviceList.SetGroupVersionKind(schema.GroupVersionKind{
+		Kind:    "ServiceList",
+		Version: "v1",
+	})
+	defaultCount := 1
+
+	// Apply the first kustomization
+	// Confirm that are
+	//  2 ConfigMaps
+	//  1 Service
+	// Confirm that the service is as expected
+	a, donea, err := wiretest.InitializeApply(objects, &object.Commit{}, buf)
+	assert.NoError(t, err)
+	defer donea()
+	_, err = a.Do()
+	assert.NoError(t, err)
+	err = a.DynamicClient.List(context.Background(), cmList, "default", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(cmList.Items), 2)
+	err = a.DynamicClient.List(context.Background(), serviceList, "default", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, defaultCount+1, len(serviceList.Items))
+	liveService := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata": map[string]interface{}{
+				"name":      "my-service",
+				"namespace": "default",
+			},
+		},
+	}
+	exist, err := util.ObjectExist(a.DynamicClient, context.Background(), liveService)
+	assert.NoError(t, err)
+	assert.Equal(t, true, exist)
+	assert.Equal(t, true, util.MatchAnnotations(liveService, service.GetAnnotations()))
+
+	// Update the kustomization by
+	//     removing the service object
+	//     changing the ConfigMapGenerator to make it generate a different ConfigMap
+	// Apply it again and Confirm that there are
+	//   3 ConfigMaps
+	//   1 Service
+	updatedObjects, err := kp.GetConfig(fs[1])
+	assert.NoError(t, err)
+	assert.NotContains(t, updatedObjects, service)
+
+	a.Resources = updatedObjects
+	_, err = a.Do()
+	assert.NoError(t, err)
 	err = a.DynamicClient.List(context.Background(), cmList, "default", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, len(cmList.Items), 3)
+	err = a.DynamicClient.List(context.Background(), serviceList, "default", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(serviceList.Items), defaultCount+1)
+	exist, err = util.ObjectExist(a.DynamicClient, context.Background(), liveService)
+	assert.NoError(t, err)
+	assert.Equal(t, true, exist)
+	assert.Equal(t, true, util.MatchAnnotations(liveService, service.GetAnnotations()))
 
+	// Run Delete on the updated kustomization
+	// Confirm that
+	//   3 ConfigMaps are deleted
+	//   the Service object still exists
 	d, doned, err := wiretest.InitializeDelete(updatedObjects, &object.Commit{}, buf)
 	defer doned()
 	assert.NoError(t, err)
 	d.DynamicClient = a.DynamicClient
 	_, err = d.Do()
 	assert.NoError(t, err)
-
 	err = d.DynamicClient.List(context.Background(), cmList, "default", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, len(cmList.Items), 0)
-
-
 	err = a.DynamicClient.List(context.Background(), serviceList, "default", nil)
 	assert.NoError(t, err)
-	assert.Equal(t, len(serviceList.Items), defaultCount + 1)
+	assert.Equal(t, len(serviceList.Items), defaultCount+1)
+	exist, err = util.ObjectExist(a.DynamicClient, context.Background(), liveService)
+	assert.NoError(t, err)
+	assert.Equal(t, true, exist)
+	assert.Equal(t, true, util.MatchAnnotations(liveService, service.GetAnnotations()))
+}
+
+func InitializeKustomizationWithService() ([]string, func(), error) {
+	f1, err := ioutil.TempDir("/tmp", "TestApply")
+	if err != nil {
+		return nil, nil, err
+	}
+	err = ioutil.WriteFile(filepath.Join(f1, "kustomization.yaml"), []byte(`
+resources:
+- not-delete-service.yaml
+
+namespace: default
+`), 0644)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(f1, "not-delete-service.yaml"), []byte(`
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+  annotations:
+    kubectl.kubernetes.io/presence: PreventDeletion
+spec:
+  selector:
+    app: MyApp
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9376
+`), 0644)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	f2, err := ioutil.TempDir("/tmp", "TestApply")
+	if err != nil {
+		return nil, nil, err
+	}
+	err = ioutil.WriteFile(filepath.Join(f2, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+resources:
+- service.yaml
+
+namespace: default
+`), 0644)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(f2, "service.yaml"), []byte(`
+apiVersion: v1
+kind: Service
+metadata:
+  name: my-service
+spec:
+  selector:
+    app: MyApp
+  ports:
+  - protocol: TCP
+    port: 80
+    targetPort: 9376
+`), 0644)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return []string{f1, f2}, func() {
+		os.RemoveAll(f1)
+		os.RemoveAll(f2)
+	}, nil
+}
+
+/* TestDeleteWithPresence verifies that Delete can delete a resource
+   when the PreventDeletion annotation is removed.
+   It takes the following steps
+   1. create a Kustomization with
+         a service with annotation PreventDeletion
+   2. apply the kustomization
+   3. confirm that there are
+         1 Service
+   4. run delete and confirm the Service is not deleted
+   5. update the Service by removing the annotation
+   6. apply the kustomization again
+   7. confirm that the Service object exists
+   8. run delete on the updated kustomization
+   9. confirm that
+         the Service is deleted
+*/
+func TestDeleteWithPresenceNoInventory(t *testing.T) {
+	buf := new(bytes.Buffer)
+	kp := wiretest.InitializConfigProvider()
+	fs, cleanup, err := InitializeKustomizationWithService()
+	defer cleanup()
+	assert.NoError(t, err)
+	assert.Equal(t, len(fs), 2)
+
+	// Setup the first kustomization
+	// Confirm that it contains a Service
+	// with the Annotation PreventDeletion
+	objects, err := kp.GetConfig(fs[0])
+	assert.NoError(t, err)
+	service := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata": map[string]interface{}{
+				"name":      "my-service",
+				"namespace": "default",
+				"annotations": map[string]interface{}{
+					"kubectl.kubernetes.io/presence": "PreventDeletion",
+				},
+			},
+			"spec": map[string]interface{}{
+				"ports": []interface{}{
+					map[string]interface{}{
+						"port":       int64(80),
+						"protocol":   "TCP",
+						"targetPort": int64(9376)},
+				},
+				"selector": map[string]interface{}{"app": "MyApp"},
+			},
+		},
+	}
+	assert.Contains(t, objects, service)
+
+	// Apply the first kustomization
+	// Confirm that the service is created
+	a, donea, err := wiretest.InitializeApply(objects, &object.Commit{}, buf)
+	assert.NoError(t, err)
+	defer donea()
+	_, err = a.Do()
+	assert.NoError(t, err)
+	liveService := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata": map[string]interface{}{
+				"name":      "my-service",
+				"namespace": "default",
+			},
+		},
+	}
+	exist, err := util.ObjectExist(a.DynamicClient, context.Background(), liveService)
+	assert.NoError(t, err)
+	assert.Equal(t, true, exist)
+	assert.Equal(t, true, util.MatchAnnotations(liveService, service.GetAnnotations()))
+
+	// Run Delete
+	// Confirm that the service is not deleted
+	d, doned, err := wiretest.InitializeDelete(objects, &object.Commit{}, buf)
+	defer doned()
+	d.DynamicClient = a.DynamicClient
+	assert.NoError(t, err)
+	_, err = d.Do()
+	assert.NoError(t, err)
+	exist, err = util.ObjectExist(a.DynamicClient, context.Background(), liveService)
+	assert.NoError(t, err)
+	assert.Equal(t, true, exist)
+	assert.Equal(t, true, util.MatchAnnotations(liveService, service.GetAnnotations()))
+
+	// Update the kustomization by
+	// removing the annotation PreventDeletion from the Service
+	// Confirm that the loaded resources
+	// have the new Service
+	updatedObjects, err := kp.GetConfig(fs[1])
+	assert.NoError(t, err)
+	updatedService := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata": map[string]interface{}{
+				"name":      "my-service",
+				"namespace": "default",
+			},
+			"spec": map[string]interface{}{
+				"ports": []interface{}{
+					map[string]interface{}{
+						"port":       int64(80),
+						"protocol":   "TCP",
+						"targetPort": int64(9376)},
+				},
+				"selector": map[string]interface{}{"app": "MyApp"},
+			},
+		},
+	}
+	assert.Contains(t, updatedObjects, updatedService)
+
+	// Run Delete on the updated kustomization
+	// Confirm that the service is not deleted
+	d.Resources = updatedObjects
+	_, err = d.Do()
+	assert.NoError(t, err)
+	exist, err = util.ObjectExist(a.DynamicClient, context.Background(), liveService)
+	assert.NoError(t, err)
+	assert.Equal(t, true, exist)
+	assert.Equal(t, true, util.MatchAnnotations(liveService, service.GetAnnotations()))
+
+
+
+	// Apply the updated kustomization
+	// (The PreventDeletion annotation is removed)
+	// Confirm that the Service annotation is removed
+	a.Resources = updatedObjects
+	_, err = a.Do()
+	assert.NoError(t, err)
+	exist, err = util.ObjectExist(a.DynamicClient, context.Background(), liveService)
+	assert.NoError(t, err)
+	assert.Equal(t, true, exist)
+	assert.Equal(t, false, util.MatchAnnotations(liveService, service.GetAnnotations()))
+
+	// Then run delete
+	// Confirm that the service is deleted
+    _, err = d.Do()
+	exist, err = util.ObjectExist(a.DynamicClient, context.Background(), liveService)
+	assert.NoError(t, err)
+	assert.Equal(t, false, exist)
 }

--- a/internal/pkg/prune/prune_test.go
+++ b/internal/pkg/prune/prune_test.go
@@ -55,7 +55,7 @@ func TestPruneWithoutInventory(t *testing.T) {
 	assert.Equal(t, len(fs), 2)
 
 	// run the prune
-	pruneObject, err := kp.GetPruneConfig(fs[1])
+	pruneObject, err := kp.GetConfig(fs[1])
 	assert.NoError(t, err)
 	p, donep, err := wiretest.InitializePrune(pruneObject, &object.Commit{}, buf)
 	defer donep()
@@ -109,7 +109,7 @@ func TestPruneOneObject(t *testing.T) {
 	assert.Equal(t, len(cmList.Items), 3)
 
 	// run the prune
-	pruneObject, err := kp.GetPruneConfig(fs[1])
+	pruneObject, err := kp.GetConfig(fs[1])
 	assert.NoError(t, err)
 	p, donep, err := wiretest.InitializePrune(pruneObject, &object.Commit{}, buf)
 	defer donep()
@@ -248,7 +248,7 @@ secretGenerator:
 	assert.Equal(t, len(sList.Items), 2)
 
 	// Run prune and assert there are no objects get deleted
-	pruneObject, err := kp.GetPruneConfig(f2)
+	pruneObject, err := kp.GetConfig(f2)
 	assert.NoError(t, err)
 	p, donep, err := wiretest.InitializePrune(pruneObject, &object.Commit{}, buf)
 	defer donep()
@@ -388,7 +388,7 @@ secretGenerator:
 	assert.Equal(t, len(sList.Items), 2)
 
 	// Run prune and assert there are no objects get deleted
-	pruneObject, err := kp.GetPruneConfig(f2)
+	pruneObject, err := kp.GetConfig(f2)
 	assert.NoError(t, err)
 	p, donep, err := wiretest.InitializePrune(pruneObject, &object.Commit{}, buf)
 	defer donep()
@@ -491,14 +491,14 @@ spec:
    2. apply the kustomization
    3. update the SecretGenerator so that the Secret that gets generated
       has a different name
-   3. add a namePrefix in the kustomization
-   4. apply the kustomization again
-   5. confirm that there are
+   4. add a namePrefix in the kustomization
+   5. apply the kustomization again
+   6. confirm that there are
          2 Secrets
          2 Deployments
          2 Services
-   6. run prune and confirms 3 objects are deleted
-   7. confirm that there are
+   7. run prune and confirms 3 objects are deleted
+   8. confirm that there are
          1 Secret
          1 Deployment
          1 Service
@@ -582,7 +582,7 @@ namePrefix: test-
 	assert.Equal(t, len(svList.Items), serviceNumber+2)
 
 	// Run prune and assert there are 3 objects get deleted
-	pruneObject, err := kp.GetPruneConfig(f2)
+	pruneObject, err := kp.GetConfig(f2)
 	assert.NoError(t, err)
 	p, donep, err := wiretest.InitializePrune(pruneObject, &object.Commit{}, buf)
 	defer donep()
@@ -606,4 +606,397 @@ namePrefix: test-
 	err = a.DynamicClient.List(ctx, svList, "default", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, len(svList.Items), serviceNumber+1)
+}
+
+func setupKustomizeWithDeclarativeDeletion(s1, s2 string) (string, error) {
+	f, err := ioutil.TempDir("/tmp", "TestApply")
+	if err != nil {
+		return "", err
+	}
+	err = ioutil.WriteFile(filepath.Join(f, "kustomization.yaml"), []byte(`apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- deployment.yaml
+- service.yaml
+
+secretGenerator:
+- name: pass
+  literals:
+  - password=secret
+
+namespace: default
+`), 0644)
+	if err != nil {
+		return "", err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(f, "deployment.yaml"), []byte(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+` + s2 + `
+spec:
+  selector:
+    matchLabels:
+      app: mysql
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+      - image: mysql:5.6
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: pass
+              key: password
+`), 0644)
+	if err != nil {
+		return "", err
+	}
+
+	err = ioutil.WriteFile(filepath.Join(f, "service.yaml"), []byte(`
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+    app: mysql
+` + s1 + `
+spec:
+  ports:
+    - port: 3306
+  selector:
+    app: mysql
+`), 0644)
+	if err != nil {
+		return "", err
+	}
+
+	return f, nil
+}
+
+var (
+	service = &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata": map[string]interface{}{
+				"name":      "mysql",
+				"namespace": "default",
+				"labels": map[string]interface{}{
+					"app": "mysql",
+				},
+			},
+			"spec": map[string]interface{}{
+				"ports": []interface{}{
+					map[string]interface{}{
+						"port": int64(3306),
+					},
+				},
+				"selector": map[string]interface{}{"app": "mysql"},
+			},
+		},
+	}
+	updatedService = &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata": map[string]interface{}{
+				"name":      "mysql",
+				"namespace": "default",
+				"labels": map[string]interface{}{
+					"app": "mysql",
+				},
+				"annotations": map[string]interface{}{
+					"kubectl.kubernetes.io/presence": "EnsureDoesNotExist",
+				},
+			},
+			"spec": map[string]interface{}{
+				"ports": []interface{}{
+					map[string]interface{}{
+						"port": int64(3306),
+					},
+				},
+				"selector": map[string]interface{}{"app": "mysql"},
+			},
+		},
+	}
+	deployment =  &unstructured.Unstructured{
+		Object:map[string]interface {}{
+			"apiVersion":"apps/v1",
+			"kind":"Deployment",
+			"metadata":map[string]interface {}{
+				"labels":map[string]interface {}{"app":"mysql"},
+				"name":"mysql",
+				"namespace":"default",
+			},
+			"spec":map[string]interface {}{
+				"selector":map[string]interface {}{
+					"matchLabels":map[string]interface {}{"app":"mysql"}},
+					"strategy":map[string]interface {}{"type":"Recreate"},
+					"template":map[string]interface {}{
+						"metadata":map[string]interface {}{
+							"labels":map[string]interface {}{
+								"app":"mysql",
+							},
+						},
+						"spec":map[string]interface {}{
+							"containers":[]interface {}{
+								map[string]interface {}{
+									"env":[]interface {}{
+										map[string]interface {}{
+											"name":"MYSQL_ROOT_PASSWORD",
+											"valueFrom":map[string]interface {}{
+												"secretKeyRef":map[string]interface {}{
+													"key":"password",
+													"name":"pass-dfg7h97cf6",
+												},
+											},
+										},
+									},
+									"image":"mysql:5.6",
+									"name":"mysql",
+								},
+							},
+						},
+					},
+			},
+		},
+	}
+
+	updatedDeployment =  &unstructured.Unstructured{
+		Object:map[string]interface {}{
+			"apiVersion":"apps/v1",
+			"kind":"Deployment",
+			"metadata":map[string]interface {}{
+				"labels":map[string]interface {}{"app":"mysql"},
+				"name":"mysql",
+				"namespace":"default",
+				"annotations": map[string]interface {}{
+					"kubectl.kubernetes.io/presence": "EnsureDoesNotExist",
+				},
+			},
+			"spec":map[string]interface {}{
+				"selector":map[string]interface {}{
+					"matchLabels":map[string]interface {}{"app":"mysql"}},
+				"strategy":map[string]interface {}{"type":"Recreate"},
+				"template":map[string]interface {}{
+					"metadata":map[string]interface {}{
+						"labels":map[string]interface {}{
+							"app":"mysql",
+						},
+					},
+					"spec":map[string]interface {}{
+						"containers":[]interface {}{
+							map[string]interface {}{
+								"env":[]interface {}{
+									map[string]interface {}{
+										"name":"MYSQL_ROOT_PASSWORD",
+										"valueFrom":map[string]interface {}{
+											"secretKeyRef":map[string]interface {}{
+												"key":"password",
+												"name":"pass-dfg7h97cf6",
+											},
+										},
+									},
+								},
+								"image":"mysql:5.6",
+								"name":"mysql",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+)
+
+/* TestPruneWithAnnotations verifies that Prune delete the resource
+   with EnsureDoesNotExist annotation.
+   It takes the following steps:
+   1. create a Kustomization with
+         a SecretGenerator
+         a Deployment that uses the generated Secret
+         a Service
+
+   2. apply the kustomization
+   3. confirm that there are
+         1 Secret
+         1 Deployment
+         1 Service
+   4. add the following annotation to the Service resource
+		 kubectl.kubernetes.io/presence: EnsureDoesNotExist
+
+   4. apply the kustomization again
+   6. run prune and confirms 1 objects is deleted
+   7. confirm that there are
+         1 Secret
+         1 Deployment
+         0 Service
+   8. add the following annotation to the Deployment resource
+         kubectl.kubernetes.io/presence: EnsureDoesNotExist
+   9. apply the kustomization again
+  10. run prune and confirms 1 objects is deleted
+  11. confirm that there are
+         1 Secret
+         0 Deployment
+         0 Service
+*/
+func TestPruneWithAnnotations(t *testing.T) {
+	buf := new(bytes.Buffer)
+	kp := wiretest.InitializConfigProvider()
+	ctx := context.Background()
+
+	// setup the first version of resource configurations
+	// and run apply
+	f1, err := setupKustomizeWithDeclarativeDeletion("", "")
+	defer os.RemoveAll(f1)
+	assert.NoError(t, err)
+	objects, err := kp.GetConfig(f1)
+	assert.NoError(t, err)
+	assert.Contains(t, objects, service)
+	assert.Contains(t, objects, deployment)
+
+	a, donea, err := wiretest.InitializeApply(objects, &object.Commit{}, buf)
+	assert.NoError(t, err)
+	defer donea()
+
+	svList := &unstructured.UnstructuredList{}
+	svList.SetGroupVersionKind(schema.GroupVersionKind{
+		Kind:    "ServiceList",
+		Version: "v1",
+	})
+	err = a.DynamicClient.List(ctx, svList, "default", nil)
+	assert.NoError(t, err)
+	serviceNumber := 1
+
+	_, err = a.Do()
+	assert.NoError(t, err)
+
+	// Confirm that there is one Service
+	err = a.DynamicClient.List(ctx, svList, "default", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(svList.Items), serviceNumber+1)
+
+	// Confirm that there is one Secret
+	sList := &unstructured.UnstructuredList{}
+	sList.SetGroupVersionKind(schema.GroupVersionKind{
+		Kind:    "SecretList",
+		Version: "v1",
+	})
+	err = a.DynamicClient.List(ctx, sList, "default", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(sList.Items), 1)
+
+	// Confirm that there is one Deployment
+	dpList := &unstructured.UnstructuredList{}
+	dpList.SetGroupVersionKind(schema.GroupVersionKind{
+		Kind:    "DeploymentList",
+		Version: "v1",
+		Group:   "apps",
+	})
+	err = a.DynamicClient.List(ctx, dpList, "default", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(dpList.Items), 1)
+
+
+	// update the kustomization by adding annotation
+	// to the Service resource
+	// and run apply
+	f2, err := setupKustomizeWithDeclarativeDeletion(`
+  annotations:
+    kubectl.kubernetes.io/presence: EnsureDoesNotExist
+`, "")
+	assert.NoError(t, err)
+	defer os.RemoveAll(f2)
+	a.Resources, err = kp.GetConfig(f2)
+	assert.NoError(t, err)
+	assert.Contains(t, a.Resources, updatedService)
+	assert.Contains(t, a.Resources, deployment)
+
+	_, err = a.Do()
+	assert.NoError(t, err)
+
+	// Confirm that there is one Service
+	err = a.DynamicClient.List(ctx, svList, "default", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(svList.Items), serviceNumber+1)
+
+	// Run prune and assert there is one object deleted
+	pruneObject, err := kp.GetConfig(f2)
+	assert.NoError(t, err)
+	p, donep, err := wiretest.InitializePrune(pruneObject, &object.Commit{}, buf)
+	defer donep()
+	assert.NoError(t, err)
+	p.DynamicClient = a.DynamicClient
+	pr, err := p.Do()
+	assert.NoError(t, err)
+	assert.Equal(t, len(pr.Resources), 1)
+
+	// Confirm that there are one Secret
+	err = a.DynamicClient.List(ctx, sList, "default", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(sList.Items), 1)
+
+	// Confirm that there are one Deployment
+	err = a.DynamicClient.List(ctx, dpList, "default", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(dpList.Items), 1)
+
+	// Confirm that there is no Service
+	err = a.DynamicClient.List(ctx, svList, "default", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(svList.Items), serviceNumber)
+
+    // update the kustomization by adding annotation
+    // to the Deployment resource
+    // and run apply
+	f3, err := setupKustomizeWithDeclarativeDeletion(`
+  annotations:
+    kubectl.kubernetes.io/presence: EnsureDoesNotExist
+`, `
+  annotations:
+    kubectl.kubernetes.io/presence: EnsureDoesNotExist
+`)
+	assert.NoError(t, err)
+	defer os.RemoveAll(f3)
+	a.Resources, err = kp.GetConfig(f3)
+	assert.NoError(t, err)
+	assert.Contains(t, a.Resources, updatedService)
+	assert.Contains(t, a.Resources, updatedDeployment)
+
+	_, err = a.Do()
+	assert.NoError(t, err)
+
+	// Run prune and assert there is one object deleted
+	pruneObject, err = kp.GetConfig(f3)
+	assert.NoError(t, err)
+	p.Resources = pruneObject
+	pr, err = p.Do()
+	assert.NoError(t, err)
+	assert.Equal(t, len(pr.Resources), 1)
+
+	// Confirm that there are one Secret
+	err = a.DynamicClient.List(ctx, sList, "default", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(sList.Items), 1)
+
+	// Confirm that there is no Deployment
+	err = a.DynamicClient.List(ctx, dpList, "default", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(dpList.Items), 0)
+
+	// Confirm that there is no Service
+	err = a.DynamicClient.List(ctx, svList, "default", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, len(svList.Items), serviceNumber)
 }

--- a/internal/pkg/resourceconfig/resourceconfig_test.go
+++ b/internal/pkg/resourceconfig/resourceconfig_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/cli-experimental/internal/pkg/resourceconfig"
 	"sigs.k8s.io/cli-experimental/internal/pkg/wirecli/wiretest"
 	"sigs.k8s.io/kustomize/pkg/inventory"
 	"sigs.k8s.io/yaml"
@@ -59,12 +58,12 @@ func TestKustomizeProvider2(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEmpty(t, objects)
 	assert.Equal(t, len(objects), 2)
-	pobject, err := kp.GetPruneConfig(f)
+	pobject, err := kp.GetConfig(f)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, pobject)
 	assert.NotNil(t, pobject)
 	inv := inventory.NewInventory()
-	inv.LoadFromAnnotation(pobject.GetAnnotations())
+	inv.LoadFromAnnotation(pobject[1].GetAnnotations())
 	assert.Equal(t, len(inv.Current), 1)
 }
 
@@ -177,7 +176,6 @@ func TestRawConfigFileProvider(t *testing.T) {
 	defer os.RemoveAll(f)
 	expected := setupExpected(t)
 
-
 	cp := wiretest.InitializeRawConfigProvider()
 	b := cp.IsSupported(f)
 	assert.Equal(t, b, true)
@@ -190,14 +188,6 @@ func TestRawConfigFileProvider(t *testing.T) {
 	assert.Equal(t, len(resources), 1)
 	assert.Equal(t, expected[0], resources[0])
 
-	resource, err := cp.GetPruneConfig(f)
-	assert.NoError(t, err)
-	assert.NotNil(t, resource)
-	assert.Equal(t, expected[1], resource)
-	resource, err = cp.GetPruneConfig(filepath.Join(f, "service.yaml"))
-	assert.NoError(t, err)
-	assert.Nil(t, resource)
-
 	b = cp.IsSupported(subdir)
 	resources, err = cp.GetConfig(subdir)
 	assert.NoError(t, err)
@@ -207,87 +197,4 @@ func TestRawConfigFileProvider(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(resources), 2)
 	assert.Equal(t, expected[1:3], resources)
-
-	resource, err = cp.GetPruneConfig(subdir)
-	assert.NoError(t, err)
-	assert.NotNil(t, resource)
-	assert.Equal(t, expected[1], resource)
-	resource, err = cp.GetPruneConfig(filepath.Join(subdir, "service.yaml"))
-	assert.NoError(t, err)
-	assert.NotNil(t, resource)
-	assert.Equal(t, expected[1], resource)
-}
-
-func setupKustomizeWithoutInventory(t *testing.T) string {
-	f, err := ioutil.TempDir("/tmp", "TestApply")
-	assert.NoError(t, err)
-	err = ioutil.WriteFile(filepath.Join(f, "kustomization.yaml"), []byte(`
-configMapGenerator:
-- name: testmap
-  literals:
-  - foo=bar
-
-secretGenerator:
-- name: testsc
-  literals:
-  - bar=baz
-
-namespace: default
-`), 0644)
-	assert.NoError(t, err)
-	return f
-}
-
-func TestGetPruneResources(t *testing.T) {
-	// with one inventory object
-	// GetPruneResources can return it
-	f := setupKustomize(t)
-	defer os.RemoveAll(f)
-	kp := wiretest.InitializConfigProvider()
-	objects, err := kp.GetConfig(f)
-	assert.NoError(t, err)
-	assert.Equal(t, len(objects), 2)
-
-	r, err := resourceconfig.GetPruneResources(objects)
-	assert.NoError(t, err)
-	assert.NotNil(t, r)
-
-	// Test the empty input
-	r, err = resourceconfig.GetPruneResources(
-		[]*unstructured.Unstructured{})
-	assert.NoError(t, err)
-	assert.Nil(t, r)
-
-	// Test the nil input
-	r, err = resourceconfig.GetPruneResources(nil)
-	assert.NoError(t, err)
-	assert.Nil(t, r)
-
-	// With no inventory object
-	// GetPruneResources returns nil
-	f2 := setupKustomizeWithoutInventory(t)
-	defer os.RemoveAll(f2)
-	kp = wiretest.InitializConfigProvider()
-	objects, err = kp.GetConfig(f2)
-	assert.NoError(t, err)
-	assert.Equal(t, len(objects), 2)
-	r, err = resourceconfig.GetPruneResources(objects)
-	assert.NoError(t, err)
-	assert.Nil(t, r)
-
-	// With multiple objects with inventory annotations
-	// GetPruneResources returns an error
-	objects, err = kp.GetConfig(f2)
-	assert.NoError(t, err)
-	assert.Equal(t, len(objects), 2)
-	for _, o := range objects {
-		o.SetAnnotations(map[string]string{
-			inventory.HashAnnotation: "12345",
-			inventory.ContentAnnotation:     `{"current": {}}`,
-		})
-	}
-	r, err = resourceconfig.GetPruneResources(objects)
-	assert.Errorf(t, err,
-		"found multiple resources with inventory annotations")
-	assert.Nil(t, r)
 }

--- a/internal/pkg/util/client_util.go
+++ b/internal/pkg/util/client_util.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cli-experimental/internal/pkg/client"
@@ -35,7 +36,7 @@ func DeleteObject(c client.Client, ctx context.Context, gvk schema.GroupVersionK
 
 	annotations := obj.GetAnnotations()
 	if presence, ok := annotations[constants.Presence]; ok {
-		if presence == constants.EnsureExist {
+		if presence == constants.PreventDeletion {
 			// not delete the resource
 			return nil, nil
 		}
@@ -48,4 +49,44 @@ func DeleteObject(c client.Client, ctx context.Context, gvk schema.GroupVersionK
 		return nil, fmt.Errorf("failed to delete %s/%s: %v", gvk.Kind, nm, err)
 	}
 	return obj, nil
+}
+
+func ObjectExist(c client.Client, ctx context.Context, u *unstructured.Unstructured) (bool, error) {
+	key := types.NamespacedName{
+		Name:      u.GetName(),
+		Namespace: u.GetNamespace(),
+	}
+	err := c.Get(ctx, key, u)
+	if err == nil {
+		return true, nil
+	}
+	if errors.IsNotFound(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+// MatchAnnotations checks if an unstructured matches a key, value pair in its annotation
+func MatchAnnotations(u *unstructured.Unstructured, annotations map[string]string) bool {
+	if u.GetAnnotations() == nil {
+		return false
+	}
+	s := labels.SelectorFromSet(labels.Set(annotations))
+	if s.Matches(labels.Set(u.GetAnnotations())) {
+		return true
+	}
+	return false
+}
+
+// HasAnnotation checks if an unstructured has a given annotation key
+func HasAnnotation(u *unstructured.Unstructured, key string) bool {
+	annotation := u.GetAnnotations()
+	if annotation == nil {
+		return false
+	}
+	_, ok := annotation[key]
+	if ok {
+		return true
+	}
+	return false
 }

--- a/internal/pkg/util/client_util.go
+++ b/internal/pkg/util/client_util.go
@@ -1,0 +1,51 @@
+package util
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cli-experimental/internal/pkg/client"
+	"sigs.k8s.io/cli-experimental/internal/pkg/constants"
+)
+
+// DeleteObject delete an object given a client and Group,Version,Kind,Name,Namespace of an object
+func DeleteObject(c client.Client, ctx context.Context, gvk schema.GroupVersionKind, ns, nm string) (
+	*unstructured.Unstructured, error) {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(gvk)
+	obj.SetNamespace(ns)
+	obj.SetName(nm)
+
+	err := c.Get(ctx, types.NamespacedName{
+		Namespace: ns,
+		Name:      nm,
+	}, obj)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to get %s/%s: %v", gvk.Kind, nm, err)
+	}
+
+	annotations := obj.GetAnnotations()
+	if presence, ok := annotations[constants.Presence]; ok {
+		if presence == constants.EnsureExist {
+			// not delete the resource
+			return nil, nil
+		}
+	}
+	err = c.Delete(ctx, obj, &metav1.DeleteOptions{})
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to delete %s/%s: %v", gvk.Kind, nm, err)
+	}
+	return obj, nil
+}

--- a/internal/pkg/wirecli/wireconfig/wireconfig.go
+++ b/internal/pkg/wirecli/wireconfig/wireconfig.go
@@ -101,7 +101,7 @@ func NewResourcePruneConfig(rcp clik8s.ResourceConfigPath,
 	p := string(rcp)
 
 	if cp.IsSupported(p) {
-		return cp.GetPruneConfig(p)
+		return cp.GetConfig(p)
 	}
 
 	return nil, nil

--- a/pkg/cmd.go
+++ b/pkg/cmd.go
@@ -18,7 +18,6 @@ import (
 	"sigs.k8s.io/cli-experimental/internal/pkg/apply"
 	"sigs.k8s.io/cli-experimental/internal/pkg/delete"
 	"sigs.k8s.io/cli-experimental/internal/pkg/prune"
-	"sigs.k8s.io/cli-experimental/internal/pkg/resourceconfig"
 	"sigs.k8s.io/cli-experimental/internal/pkg/status"
 )
 
@@ -48,12 +47,8 @@ func (a *Cmd) Apply(resources []*unstructured.Unstructured) error {
 
 // Prune prunes resources given the input as a slice of unstructured resources
 func (a *Cmd) Prune(resources []*unstructured.Unstructured) error {
-	pruneResource, err := resourceconfig.GetPruneResources(resources)
-	if err != nil {
-		return err
-	}
-	a.Pruner.Resources = pruneResource
-	_, err = a.Pruner.Do()
+	a.Pruner.Resources = resources
+	_, err := a.Pruner.Do()
 	return err
 }
 


### PR DESCRIPTION
Add two annotations
```
kubectl.kubernetes.io/presence: PreventDeletion
kubectl.kubernetes.io/presence: EnsureDoesNotExist
```

In apply command, any resource annotated by `EnsureDoesNotExist` won't be applied.
In prune or delete command, any resource annotated by `PreventDeletion` won't be deleted.
