### PR TITLE
update kustomize to 2.1.0 and fix the resource ordering issue

### DIFF
--- a/cmd/apply/status/status_test.go
+++ b/cmd/apply/status/status_test.go
@@ -78,7 +78,7 @@ func TestStatusPod(t *testing.T) {
 	wirek8s.Flags(cmd.PersistentFlags())
 
 	assert.NoError(t, cmd.Execute())
-	assert.Equal(t, "Doing `cli-experimental apply`\napplied ConfigMap/example-cfgmap\napplied Deployment/frontend\napplied Pod/myapp-pod\napplied StatefulSet/web\nResources: 4\n", buf.String()) // nolint
+	assert.Equal(t, "Doing `cli-experimental apply`\napplied Pod/myapp-pod\napplied ConfigMap/example-cfgmap\napplied StatefulSet/web\napplied Deployment/frontend\nResources: 4\n", buf.String()) // nolint
 
 	cmd = status.GetApplyStatusCommand(args, false)
 	buf.Reset()
@@ -87,5 +87,5 @@ func TestStatusPod(t *testing.T) {
 	wirek8s.Flags(cmd.PersistentFlags())
 
 	assert.NoError(t, cmd.Execute())
-	assert.Equal(t, "Deployment/frontend   Pending \nStatefulSet/web   Pending \nConfigMap/example-cfgmap   Ready\nPod/myapp-pod   Pending Phase: Pending\n", buf.String())
+	assert.Equal(t, "Pod/myapp-pod   Pending Phase: Pending\nConfigMap/example-cfgmap   Ready\nStatefulSet/web   Pending \nDeployment/frontend   Pending \n", buf.String())
 }

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,6 @@ require (
 	golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 // indirect
 	golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c // indirect
 	golang.org/x/oauth2 v0.0.0-20190319182350-c85d3e98c914 // indirect
-	golang.org/x/sync v0.0.0-20190423024810-112230192c58 // indirect
 	golang.org/x/sys v0.0.0-20190506115046-ca7f33d4116e // indirect
 	golang.org/x/text v0.3.2 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect
@@ -48,7 +47,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20190320154901-5e45bb682580 // indirect
 	k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7 // indirect
 	sigs.k8s.io/controller-runtime v0.1.10
-	sigs.k8s.io/kustomize v0.0.0-20190501180958-e42933ec54ce
+	sigs.k8s.io/kustomize v2.1.0+incompatible
 	sigs.k8s.io/testing_frameworks v0.1.1 // indirect
 	sigs.k8s.io/yaml v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -223,7 +223,6 @@ golang.org/x/net v0.0.0-20181114220301-adae6a3d119a/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/net v0.0.0-20190225153610-fe579d43d832/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190420063019-afa5a82059c6 h1:HdqqaWmYAUI7/dmByKKEw+yxDksGSo+9GjkUc9Zp34E=
@@ -272,6 +271,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190422233926-fe54fb35175b h1:NVD8gBK33xpdqCaZVVtd6OFJp+3dxkXuz7+U7KaVN6s=
 golang.org/x/tools v0.0.0-20190422233926-fe54fb35175b/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190608022120-eacb66d2a7c3/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 google.golang.org/api v0.0.0-20181220000619-583d854617af/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.2.0 h1:B5VXkdjt7K2Gm6fGBC9C9a1OAKJDT95cTqwet+2zib0=
 google.golang.org/api v0.2.0/go.mod h1:IfRCZScioGtypHNTlz3gFk67J8uePVW7uDTBzXuIkhU=
@@ -334,8 +334,8 @@ k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7 h1:8r+l4bNWjRlsFYlQJnKJ2p7s1YQPj
 k8s.io/utils v0.0.0-20190308190857-21c4ce38f2a7/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 sigs.k8s.io/controller-runtime v0.1.10 h1:amLOmcekVdnsD1uIpmgRqfTbQWJ2qxvQkcdeFhcotn4=
 sigs.k8s.io/controller-runtime v0.1.10/go.mod h1:HFAYoOh6XMV+jKF1UjFwrknPbowfyHEHHRdJMf2jMX8=
-sigs.k8s.io/kustomize v0.0.0-20190501180958-e42933ec54ce h1:UX22qu/kMuYC+AqvpezhFXhC3KYT+H3ljpBHfzkRWlc=
-sigs.k8s.io/kustomize v0.0.0-20190501180958-e42933ec54ce/go.mod h1:a8nuEzCyR92EJG3pQV/GAGxK0vKxbPFaonptzq4IVhg=
+sigs.k8s.io/kustomize v2.1.0+incompatible h1:SNNM2R08nEdcHa7ch9RifNfxwPb1v5hQXBsK4/RfUvc=
+sigs.k8s.io/kustomize v2.1.0+incompatible/go.mod h1:ld+RBLeKP/m3I1xsa/iFL9BMRqaM/+LoMhWsrmYrY/s=
 sigs.k8s.io/testing_frameworks v0.1.1 h1:cP2l8fkA3O9vekpy5Ks8mmA0NW/F7yBdXf8brkWhVrs=
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=

--- a/internal/pkg/apply/apply.go
+++ b/internal/pkg/apply/apply.go
@@ -58,7 +58,7 @@ func (a *Apply) Do() (Result, error) {
 
 	for _, u := range normalizeResourceOrdering(a.Resources) {
 		annotation := u.GetAnnotations()
-		_, ok := annotation[inventory.InventoryAnnotation]
+		_, ok := annotation[inventory.ContentAnnotation]
 
 		if ok {
 			var err error
@@ -91,16 +91,16 @@ func (a Apply) updateInventoryObject(u *unstructured.Unstructured) (*unstructure
 
 	oldAnnotation := obj.GetAnnotations()
 	newAnnotation := u.GetAnnotations()
-	oldhash, okold := oldAnnotation[inventory.InventoryHashAnnotation]
-	newhash, oknew := newAnnotation[inventory.InventoryHashAnnotation]
+	oldhash, okold := oldAnnotation[inventory.HashAnnotation]
+	newhash, oknew := newAnnotation[inventory.HashAnnotation]
 	if okold && oknew && oldhash == newhash {
 		return obj, nil
 	}
 
-	return mergeInventoryAnnotation(u, obj)
+	return mergeContentAnnotation(u, obj)
 }
 
-func mergeInventoryAnnotation(newObj, oldObj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+func mergeContentAnnotation(newObj, oldObj *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	newInv := inventory.NewInventory()
 	err := newInv.LoadFromAnnotation(newObj.GetAnnotations())
 	if err != nil {
@@ -126,7 +126,7 @@ func normalizeResourceOrdering(resources clik8s.ResourceConfigs) []*unstructured
 	index := -1
 	for i, u := range resources {
 		annotation := u.GetAnnotations()
-		_, ok := annotation[inventory.InventoryAnnotation]
+		_, ok := annotation[inventory.ContentAnnotation]
 		if ok {
 			index = i
 		} else {

--- a/internal/pkg/delete/delete.go
+++ b/internal/pkg/delete/delete.go
@@ -56,7 +56,7 @@ func (a *Delete) Do() (Result, error) {
 	ctx := context.Background()
 	for _, u := range normalizeResourceOrdering(a.Resources) {
 		annotations := u.GetAnnotations()
-		_, ok := annotations[inventory.InventoryAnnotation]
+		_, ok := annotations[inventory.ContentAnnotation]
 		if ok {
 			err := a.handleInventroy(ctx, annotations)
 			if err != nil {
@@ -125,7 +125,7 @@ func normalizeResourceOrdering(resources clik8s.ResourceConfigs) []*unstructured
 	index := -1
 	for i, u := range resources {
 		annotation := u.GetAnnotations()
-		_, ok := annotation[inventory.InventoryAnnotation]
+		_, ok := annotation[inventory.ContentAnnotation]
 		if ok {
 			index = i
 		} else {

--- a/internal/pkg/prune/prune.go
+++ b/internal/pkg/prune/prune.go
@@ -64,7 +64,7 @@ func (o *Prune) Do() (Result, error) {
 
 	u := (*unstructured.Unstructured)(o.Resources)
 	annotation := u.GetAnnotations()
-	_, ok := annotation[inventory.InventoryAnnotation]
+	_, ok := annotation[inventory.ContentAnnotation]
 	if !ok {
 		return Result{}, nil
 	}

--- a/internal/pkg/resourceconfig/resourceconfig_test.go
+++ b/internal/pkg/resourceconfig/resourceconfig_test.go
@@ -282,8 +282,8 @@ func TestGetPruneResources(t *testing.T) {
 	assert.Equal(t, len(objects), 2)
 	for _, o := range objects {
 		o.SetAnnotations(map[string]string{
-			inventory.InventoryHashAnnotation: "12345",
-			inventory.InventoryAnnotation:     `{"current": {}}`,
+			inventory.HashAnnotation: "12345",
+			inventory.ContentAnnotation:     `{"current": {}}`,
 		})
 	}
 	r, err = resourceconfig.GetPruneResources(objects)

--- a/internal/pkg/wirecli/wireconfig/wireconfig.go
+++ b/internal/pkg/wirecli/wireconfig/wireconfig.go
@@ -19,10 +19,10 @@ import (
 	"sigs.k8s.io/cli-experimental/internal/pkg/clik8s"
 	"sigs.k8s.io/cli-experimental/internal/pkg/resourceconfig"
 	"sigs.k8s.io/kustomize/k8sdeps/kunstruct"
-	"sigs.k8s.io/kustomize/k8sdeps/kv/plugin"
 	ktransformer "sigs.k8s.io/kustomize/k8sdeps/transformer"
 	"sigs.k8s.io/kustomize/pkg/fs"
 	"sigs.k8s.io/kustomize/pkg/ifc/transformer"
+	"sigs.k8s.io/kustomize/pkg/plugins"
 	"sigs.k8s.io/kustomize/pkg/resmap"
 	"sigs.k8s.io/kustomize/pkg/resource"
 	"sigs.k8s.io/kustomize/pkg/types"
@@ -51,17 +51,14 @@ var RawConfigProviderSet = wire.NewSet(
 
 // NewPluginConfig returns a new PluginConfig
 func NewPluginConfig() *types.PluginConfig {
-	pc := plugin.DefaultPluginConfig()
-	pc.GoEnabled = true
+	pc := plugins.DefaultPluginConfig()
+	pc.Enabled = true
 	return pc
 }
 
 // NewResMapFactory returns a rew ResMap Factory
 func NewResMapFactory(pc *types.PluginConfig) *resmap.Factory {
-	uf := kunstruct.NewKunstructuredFactoryWithGeneratorArgs(
-		&types.GeneratorMetaArgs{
-			PluginConfig: pc,
-		})
+	uf := kunstruct.NewKunstructuredFactoryImpl()
 	return resmap.NewFactory(resource.NewFactory(uf))
 }
 

--- a/pkg/cmd_test.go
+++ b/pkg/cmd_test.go
@@ -61,8 +61,8 @@ func setupResourcesV1() []*unstructured.Unstructured {
 	r2.SetName("inventory")
 	r2.SetNamespace("default")
 	r2.SetAnnotations(map[string]string{
-		inventory.InventoryAnnotation:     "{\"current\":{\"~G_v1_ConfigMap|default|cm1\":null}}",
-		inventory.InventoryHashAnnotation: "1234567",
+		inventory.ContentAnnotation:     "{\"current\":{\"~G_v1_ConfigMap|default|cm1\":null}}",
+		inventory.HashAnnotation: "1234567",
 	})
 	return []*unstructured.Unstructured{r1, r2}
 }
@@ -87,8 +87,8 @@ func setupResourcesV2() []*unstructured.Unstructured {
 	r2.SetName("inventory")
 	r2.SetNamespace("default")
 	r2.SetAnnotations(map[string]string{
-		inventory.InventoryAnnotation:     "{\"current\":{\"~G_v1_ConfigMap|default|cm2\":null}}",
-		inventory.InventoryHashAnnotation: "7654321",
+		inventory.ContentAnnotation:     "{\"current\":{\"~G_v1_ConfigMap|default|cm2\":null}}",
+		inventory.HashAnnotation: "7654321",
 	})
 	return []*unstructured.Unstructured{r1, r2}
 }


### PR DESCRIPTION
The ordering problem is fixed. Now the order is the same as
the resource presence order in the kustomization.yaml file.