### PR TITLE
fix built deployment name in nameprefix docs

### DIFF
--- a/site/content/en/references/kustomize/nameprefix/_index.md
+++ b/site/content/en/references/kustomize/nameprefix/_index.md
@@ -45,7 +45,7 @@ resources:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: alices-the-deployment
+  name: overlook-the-deployment
 spec:
   replicas: 5
   template:


### PR DESCRIPTION
This PR adjusts the generated deployment name to match the one specified in kustomization's nameprefix