### PR TITLE
Fix namePrefix example

### DIFF
--- a/site/content/en/references/kustomize/nameprefix/_index.md
+++ b/site/content/en/references/kustomize/nameprefix/_index.md
@@ -32,7 +32,7 @@ spec:
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namePrefix: overlook-
+namePrefix: alices-
 
 resources:
 - deployment.yaml


### PR DESCRIPTION
The example `namePrefix` doesn't match the output -- this corrects that.