### PR TITLE
Update _index.md

### DIFF
--- a/site/content/en/references/kustomize/nameprefix/_index.md
+++ b/site/content/en/references/kustomize/nameprefix/_index.md
@@ -45,7 +45,7 @@ resources:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: alices-the-deployment
+  name: overlook-the-deployment
 spec:
   replicas: 5
   template:


### PR DESCRIPTION
Fix deployment name in the build output.
Since namePrefix is set to `overlook-` in `kustomization.yaml`, kustomize changes the deployment name to `overlook-the-deployment`.

```
➤ kustomize build .
apiVersion: apps/v1
kind: Deployment
metadata:
  name: overlook-the-deployment
spec:
  replicas: 5
  template:
    containers:
    - image: registry/conatiner:latest
      name: the-container
```