### PR TITLE
Clarify the usage of "image name"

### DIFF
--- a/site/content/en/references/kustomize/kustomization/images/_index.md
+++ b/site/content/en/references/kustomize/kustomization/images/_index.md
@@ -24,7 +24,7 @@ tag.
 
 | Field     | Description                                                              | Example Field | Example Result |
 |-----------|--------------------------------------------------------------------------|----------| --- |
-| `name`    | Match images with this image name| `name: nginx`| |
+| `name`    | Match images with this _image_ name (not the _container_ name) | `nginx` (not `nginxapp`) | |
 | `newTag`  | Override the image **tag** or **digest** for images whose image name matches `name`    | `newTag: new` | `nginx:old` -> `nginx:new` |
 | `newName` | Override the image **name** for images whose image name matches `name`   | `newName: nginx-special` | `nginx:old` -> `nginx-special:old` |
 


### PR DESCRIPTION
My colleague and I were banging our heads against the wall trying get get the `kustomize edit set image` command to work until we realised that we were mixing up the "container name" and the "image name" values. This distinction is hidden when the image name and the container name is the same (e.g. just "nginx" as we saw in other blog posts). It might help to highlight that in the documentation, as proposed.