### PR TITLE
Correct a typo in resources_controllers.md

### DIFF
--- a/site/content/en/guides/introduction/resources_controllers.md
+++ b/site/content/en/guides/introduction/resources_controllers.md
@@ -219,7 +219,7 @@ Shared Configuration and Secret data may be provided by ConfigMaps and Secrets. 
 Environment Variables, Command Line Arguments and Files to be loosely injected into
 the Pods and Containers that consume them.
 
-{{< alert color="success" title="Internal vs External Services" >}}
+{{< alert color="success" title="ConfigMaps vs Secrets" >}}
 - [ConfigMaps](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/)
   are for providing non-sensitive data to Pods.
 - [Secrets](https://kubernetes.io/docs/concepts/configuration/secret/)


### PR DESCRIPTION
Correct a typo in "Configurations and Secrets" section.
The subsection that is comparing configmaps and secrets is mistakenly titled "Internal vs External Services".
I propose to change it to "ConfigMaps vs Secrets".