### PR TITLE
Reference to the container was wrong

### DIFF
--- a/site/content/en/references/kustomize/replicas/_index.md
+++ b/site/content/en/references/kustomize/replicas/_index.md
@@ -67,7 +67,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 replicas:
-- name: deployment-name
+- name: the-container
   count: 10
 
 resources:


### PR DESCRIPTION
If I understand it correctly the reference should be `the-container` instead of `deployment-name` to update the replica count for that specific container spec.