### PR TITLE
Update _index.md

### DIFF
--- a/site/content/en/contributing/docs/_index.md
+++ b/site/content/en/contributing/docs/_index.md
@@ -14,7 +14,7 @@ forked from the [docsy-example](https://github.com/google/docsy-example)
 
 - [Install hugo](https://gohugo.io/getting-started/installing/#fetch-from-github)
 - Clone kustomize
-  - `https://github.com/kubernetes-sigs/cli-experimental.git && cd site/`
+  - `git clone https://github.com/kubernetes-sigs/cli-experimental.git && cd site/`
 
 ## Development
 

--- a/site/content/en/contributing/docs/_index.md
+++ b/site/content/en/contributing/docs/_index.md
@@ -14,7 +14,7 @@ forked from the [docsy-example](https://github.com/google/docsy-example)
 
 - [Install hugo](https://gohugo.io/getting-started/installing/#fetch-from-github)
 - Clone kustomize
-  - `git clone git@github.com:kubernetes-sigs/cli-experimental && cd site/`
+  - `https://github.com/kubernetes-sigs/cli-experimental.git && cd site/`
 
 ## Development
 


### PR DESCRIPTION
Updated the git clone url from
git@github.com:kubernetes-sigs/cli-experimental
to
https://github.com/kubernetes-sigs/cli-experimental.git
As to clone the existing URL users are required public key from github , if we can change to https , no user can face issue to clone the repository