### PR TITLE
Update _index.md

### DIFF
--- a/site/content/en/references/kubectl/create/secret/_index.md
+++ b/site/content/en/references/kubectl/create/secret/_index.md
@@ -40,7 +40,7 @@ my-secret             Opaque                    1      14s
 ## `generic`
 - Create a secret from a local file, directory or literal value
 ```bash
-$ kubectl create generic NAME [--type=string] [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run=server|client|none]
+$ kubectl create secret generic NAME [--type=string] [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run=server|client|none]
 ```
 
 ## Example


### PR DESCRIPTION
Fix typo/missing command in documentation

_kubectl create generic_ is typo. Should be **kubectl create secret generic**