### PR TITLE
Fix typos in builtins.md

### DIFF
--- a/site/content/en/guides/extending_kustomize/builtins.md
+++ b/site/content/en/guides/extending_kustomize/builtins.md
@@ -46,7 +46,7 @@ complete plugin argument specification.
 
 #### field name: `commonAnnotations`
 
-Adds annotations (non-identifying metadata) to add
+Adds annotations (non-identifying metadata) to
 all resources. Like labels, these are key value
 pairs.
 

--- a/site/content/en/guides/extending_kustomize/builtins.md
+++ b/site/content/en/guides/extending_kustomize/builtins.md
@@ -46,7 +46,7 @@ complete plugin argument specification.
 
 #### field name: `commonAnnotations`
 
-Adds annotions (non-identifying metadata) to add
+Adds annotations (non-identifying metadata) to add
 all resources. Like labels, these are key value
 pairs.
 


### PR DESCRIPTION
- `s/annotions/annotations/`
- remove extraneous "all"