### PR TITLE
Fix typo in Kustomize Multibase example

### DIFF
--- a/site/content/en/guides/example/multi_base.md
+++ b/site/content/en/guides/example/multi_base.md
@@ -119,7 +119,7 @@ resources:
 namePrefix: cluster-a-
 ```
 
-## `directory sturcture`
+## `directory structure`
 > ```bash
 > .
 > ├── kustomization.yaml


### PR DESCRIPTION
Structure was misspelled in a title.