### PR TITLE
Fix alpha plugins CLI switch to be hyphens

### DIFF
--- a/site/content/en/guides/extending_kustomize/_index.md
+++ b/site/content/en/guides/extending_kustomize/_index.md
@@ -180,7 +180,7 @@ of _"plugin security"_.
 A `kustomize build` that tries to use plugins but
 omits the flag
 
-> `--enable_alpha_plugins`
+> `--enable-alpha-plugins`
 
 will not load plugins and will fail with a
 warning about plugin use.


### PR DESCRIPTION
This matches the output of `kustomize build --help`:

```
Flags:
      --allow-id-changes         enable changes to a resourceId
      --enable-alpha-plugins     enable kustomize plugins
      --enable-exec              enable support for exec functions -- note: exec functions run arbitrary code -- do not use for untrusted configs!!! (Alpha)
```