### PR TITLE
Remove silent curl flag

### DIFF
--- a/site/content/en/installation/kustomize/binaries.md
+++ b/site/content/en/installation/kustomize/binaries.md
@@ -13,7 +13,7 @@ The following [script] detects your OS and downloads the appropriate kustomize b
 current working directory.
 
 ```bash
-curl -s "https://raw.githubusercontent.com/\
+curl "https://raw.githubusercontent.com/\
 kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
 ```
 


### PR DESCRIPTION
By adding the silent flag errors in curl are suppressed, leaving users with a blank terminal not indicating the install succeeds or fails. Removing the silent flag should let the user know the progress of the download as well as show them any errors.