### PR TITLE
Fix broken link to glossary in kustomize FAQ

### DIFF
--- a/site/content/en/faq/kustomize/_index.md
+++ b/site/content/en/faq/kustomize/_index.md
@@ -41,7 +41,7 @@ Resources (including configmap and secret generators)
 can _still be shared_ via the recommended best practice
 of placing them in a directory with their own
 kustomization file, and referring to this directory as a
-[`base`](/kustomize/api-reference/glossary#base) from any kustomization that
+[`base`](/references/kustomize/glossary/#base) from any kustomization that
 wants to use it.  This encourages modularity and
 relocatability.
 


### PR DESCRIPTION
# How to reproduce

In https://kubectl.docs.kubernetes.io/faq/kustomize/, the link to `base` in "(...) and referring to this directory as a **base** from any kustomization (...)" currently sends the reader to https://kubectl.docs.kubernetes.io/kustomize/api-reference/glossary#base.

# Proposed Change

https://kubectl.docs.kubernetes.io/references/kustomize/glossary/#base seems to be the current place for the glossary, so I changed the link to point to it.