### PR TITLE
Update the link to Components KEP page

### DIFF
--- a/site/content/en/guides/config_management/components.md
+++ b/site/content/en/guides/config_management/components.md
@@ -16,7 +16,7 @@ optional features and you wish to enable only a subset of them in different
 overlays, i.e., different features for different environments or audiences.
 
 For more details regarding this feature you can read the
-[Kustomize Components KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/1802-kustomize-components.md).
+[Kustomize Components KEP](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/1802-kustomize-components).
 
 ## Use case
 


### PR DESCRIPTION
Correct the link to the Kustomize Components KEP page which is currently opening a non-existent page. 

Signed-off-by: Chetan Banavikalmutt <chetanrns1997@gmail.com>