### PR TITLE
Fixed typo in Build Output example

### DIFF
--- a/site/content/en/references/kustomize/kustomization/nameprefix/_index.md
+++ b/site/content/en/references/kustomize/kustomization/nameprefix/_index.md
@@ -24,7 +24,7 @@ spec:
   template:
     containers:
       - name: the-container
-        image: registry/conatiner:latest
+        image: registry/container:latest
 ```
 
 ```yaml
@@ -45,12 +45,12 @@ resources:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: alices-the-deployment
+  name: overlook-the-deployment
 spec:
   replicas: 5
   template:
     containers:
-    - image: registry/conatiner:latest
+    - image: registry/container:latest
       name: the-container
 ```
 


### PR DESCRIPTION
There was a simple error in the example's output.