### PR TITLE
update secretGenerator documentation

### DIFF
--- a/site/content/en/references/kustomize/kustomization/secretgenerator/_index.md
+++ b/site/content/en/references/kustomize/kustomization/secretgenerator/_index.md
@@ -25,7 +25,10 @@ secretGenerator:
   # you can define a namespace to generate
   # a secret in, defaults to: "default"
   namespace: apps
+  # if you do not specify a key, the
+  # filename is used as key inside data
   files:
+  # - key=filename
   - tls.crt=catsecret/tls.cert
   - tls.key=secret/tls.key
   type: "kubernetes.io/tls"


### PR DESCRIPTION
I am adding this as it was not immediately obvious to me from the documentation alone.
I ended up digging in the source code and found this in the tests:
https://github.com/kubernetes-sigs/kustomize/blob/master/plugin/builtin/secretgenerator/SecretGenerator_test.go#L39

This is a nice feature to be aware of, e.g. in Jenkins `kubernetes-credentials-provider`
plugin, the secret data has to be inside `data.data`, and it is hard coded:
https://github.com/jenkinsci/kubernetes-credentials-provider-plugin/blob/master/src/main/java/com/cloudbees/jenkins/plugins/kubernetes_credentials_provider/convertors/FileCredentialsConvertor.java#L53
Or else, it throws an errors similar to this:
```
WARNING c.c.j.p.k.KubernetesCredentialProvider#convertSecret: Failed to convert Secret 'SECRET_NAME_HERE' of type secretFile due to secretFile credential is missing the data 
```