### PR TITLE
Fix namePrefix documentation typo

### DIFF
--- a/site/content/en/references/kustomize/kustomization/nameprefix/_index.md
+++ b/site/content/en/references/kustomize/kustomization/nameprefix/_index.md
@@ -45,7 +45,7 @@ resources:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: alices-the-deployment
+  name: overlook-the-deployment
 spec:
   replicas: 5
   template:


### PR DESCRIPTION
Found some typos in the [docs for namePrefix](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/nameprefix/) where the `namePrefix` did not match the build output example. :)