### PR TITLE
Update _index.md to show correct build output

### DIFF
--- a/site/content/en/references/kustomize/kustomization/nameprefix/_index.md
+++ b/site/content/en/references/kustomize/kustomization/nameprefix/_index.md
@@ -45,7 +45,7 @@ resources:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: alices-the-deployment
+  name: the-container-the-deployment
 spec:
   replicas: 5
   template:


### PR DESCRIPTION
Fixed that the shown build output does not display the correct name.