### PR TITLE
docs: fix invalid --enable_alpha_plugins flag

### DIFF
--- a/site/content/en/guides/extending_kustomize/exec_plugins.md
+++ b/site/content/en/guides/extending_kustomize/exec_plugins.md
@@ -278,7 +278,7 @@ tree $DEMO
 ### Build your app
 
 ```bash
-XDG_CONFIG_HOME=$DEMO $DEMO/bin/kustomize build --enable_alpha_plugins $MYAPP
+XDG_CONFIG_HOME=$DEMO $DEMO/bin/kustomize build --enable-alpha-plugins $MYAPP
 ```
 
 Above, if you had set

--- a/site/content/en/guides/extending_kustomize/go_plugins.md
+++ b/site/content/en/guides/extending_kustomize/go_plugins.md
@@ -593,7 +593,7 @@ This should look something like:
 ### Build your app
 
 ```shell
-XDG_CONFIG_HOME=$DEMO $tmpGoPath/bin/kustomize build --enable_alpha_plugins $MYAPP
+XDG_CONFIG_HOME=$DEMO $tmpGoPath/bin/kustomize build --enable-alpha-plugins $MYAPP
 ```
 
 This should emit a kubernetes secret, with

--- a/site/content/zh/guides/plugins/_index.md
+++ b/site/content/zh/guides/plugins/_index.md
@@ -122,7 +122,7 @@ $XDG_CONFIG_HOME/kustomize/plugin
 
 Kustomize 插件不会在任何形式的 kustomize 提供的沙盒中运行。不存在 _"plugin security"_ 的概念。
 
-`kustomize build` 会尝试使用插件，但如果省略了 `--enable_alpha_plugins`，将导致插件无法加载，并且会有一个关于插件使用的警告。
+`kustomize build` 会尝试使用插件，但如果省略了 `--enable-alpha-plugins`，将导致插件无法加载，并且会有一个关于插件使用的警告。
 
 使用这个 flag 就是承认使用不稳定的插件 API（alpha）、承认使用缺少出处插件，以及插件不属于 kustomize 的事实。
 

--- a/site/content/zh/guides/plugins/execPluginGuidedExample.md
+++ b/site/content/zh/guides/plugins/execPluginGuidedExample.md
@@ -200,7 +200,7 @@ tree $DEMO
 ## 使用插件构建 APP
 
 ```bash
-XDG_CONFIG_HOME=$DEMO $DEMO/bin/kustomize build --enable_alpha_plugins $MYAPP
+XDG_CONFIG_HOME=$DEMO $DEMO/bin/kustomize build --enable-alpha-plugins $MYAPP
 ```
 
 之前如果您已经设置了 `PLUGIN_ROOT=$HOME/.config/kustomize/plugin`，则无需在 _kustomize_ 命令前使用 `XDG_CONFIG_HOME`。

--- a/site/content/zh/guides/plugins/goPluginGuidedExample.md
+++ b/site/content/zh/guides/plugins/goPluginGuidedExample.md
@@ -299,7 +299,7 @@ tree $DEMO
 ## 使用插件构建您的应用
 
 ```shell
-XDG_CONFIG_HOME=$DEMO $tmpGoPath/bin/kustomize build --enable_alpha_plugins $MYAPP
+XDG_CONFIG_HOME=$DEMO $tmpGoPath/bin/kustomize build --enable-alpha-plugins $MYAPP
 ```
 
 这将生成一个 kubernetes secret，并对名称 `ROCKET` 和 `CAR` 的数据进行加密。


### PR DESCRIPTION
This should be `--enable-alpha-plugins` with hyphens, not underscores:

```sh
$ kustomize build --help | grep plugins
      --enable-alpha-plugins     enable kustomize plugins
```

Fixes #122.