### PR TITLE
Update execPluginGuidedExample.md

### DIFF
--- a/site/content/en/guides/extending_kustomize/execPluginGuidedExample.md
+++ b/site/content/en/guides/extending_kustomize/execPluginGuidedExample.md
@@ -225,5 +225,5 @@ tree $DEMO
 
 ```bash
 export KUSTOMIZE_PLUGIN_ROOT
-$DEMO/bin/kustomize build --enable_alpha_plugins $MYAPP
+$DEMO/bin/kustomize build --enable-alpha-plugins $MYAPP
 ```

--- a/site/content/en/guides/extending_kustomize/execPluginGuidedExample.md
+++ b/site/content/en/guides/extending_kustomize/execPluginGuidedExample.md
@@ -134,13 +134,16 @@ ls -C1 $MYAPP
 
 ## Make a home for plugins
 
-Plugins must live in a particular place for
-kustomize to find them.
+By default plugins are searched for in the following locations:
+
+- `$HOME/kustomize/plugin`
+- `$XDG_CONFIG_HOME/kustomize/plugin`
+- `$KUSTOMIZE_PLUGIN_HOME`
 
 This demo will use the ephemeral directory:
 
 ```bash
-PLUGIN_ROOT=$DEMO/kustomize/plugin
+KUSTOMIZE_PLUGIN_ROOT=$DEMO/plugin
 ```
 
 The plugin config defined above in
@@ -155,7 +158,7 @@ This means the plugin must live in a directory
 named:
 
 ```bash
-MY_PLUGIN_DIR=$PLUGIN_ROOT/myDevOpsTeam/sillyconfigmapgenerator
+MY_PLUGIN_DIR=$KUSTOMIZE_PLUGIN_ROOT/myDevOpsTeam/sillyconfigmapgenerator
 
 mkdir -p $MY_PLUGIN_DIR
 ```
@@ -178,7 +181,7 @@ must match the plugin's _kind_ (in this case,
 
 ```bash
 # $MY_PLUGIN_DIR/SillyConfigMapGenerator
-#!/bin/bash
+#!/usr/bin/env bash
 # Skip the config file name argument.
 shift
 today=`date +%F`
@@ -221,14 +224,6 @@ tree $DEMO
 ## Build your app, using the plugin
 
 ```bash
-XDG_CONFIG_HOME=$DEMO $DEMO/bin/kustomize build --enable_alpha_plugins $MYAPP
+export KUSTOMIZE_PLUGIN_ROOT
+$DEMO/bin/kustomize build --enable_alpha_plugins $MYAPP
 ```
-
-Above, if you had set
-
-> ```bash
-> PLUGIN_ROOT=$HOME/.config/kustomize/plugin
-> ```
-
-there would be no need to use `XDG_CONFIG_HOME` in the
-_kustomize_ command above.


### PR DESCRIPTION
As I was going through the exec plugin tutorial I found a few pieces confusing.  I updated the docs to reflect the latest behavior I noticed.  I hope these edits are ok :)

----

**Problem:**

- Plugins are searched in several places but the documentation does not make that clear.
- Additionally, the docs show an example of setting `XDG_HOME_DIR` when a simpler alternative exists.
- `--enable_alpha_plugins` is not an option according to `--help`

**Solution:**

- Document all the locations where plugins are searched.
- Utilize `KUSTOMIZE_PLUGIN_ROOT` as it is the simplest solution.
- Update argument to `--enable-alpha-plugins` as shown by `--help`