### PR TITLE
Minor grammar nits

### DIFF
--- a/site/content/en/references/kustomize/kustomization/_index.md
+++ b/site/content/en/references/kustomize/kustomization/_index.md
@@ -158,8 +158,8 @@ In these interfaces, a `ResMap` is a list of kubernetes `Resource`s
 with ancillary map-like lookup and modification methods.
 
 A generator cannot be a transformer, because it doesn't accept an
-input other than its own configuration.  Configuration for both G's
-and T's are done via a distinct (and common) interface.
+input other than its own configuration.  Configuration for both generators
+and transformers are done via a distinct (and common) interface.
 
 A transformer doesn't implement `Generator`, but it's capable of
 behaving like one.
@@ -188,7 +188,7 @@ can call these methods - creating, sorting, destroying, etc.
 
 Transformers have a general generative power.
 
-A kustomization overlay, could, say, fix common oversites made in
+A kustomization overlay, could, say, fix common oversights made in
 cluster configuration.
 
 For example, a transformer could scan all resources, looking for the


### PR DESCRIPTION
There is widespread confusion around the use of apostrophes for pluralization. The rules governing this are really a hot mess, which leads to many misuses. But if you pay careful attention to well-edited documents, you'll almost never see it used. The best rule of thumb is, you never really _need_ them, so it's best to reword your sentences to avoid them entirely.

There are a few valid cases for pluralization with apostrophes, but the whole thing is a general mess so is better avoided when possible. See https://www.dailywritingtips.com/when-to-form-a-plural-with-an-apostrophe/ for a good treatment of the topic.

In this document's example, it's best to just spell out the words for clarity.