### PR TITLE
[fix] Containerized KRM Functions sample yaml is missing one line.

### DIFF
--- a/site/content/en/guides/extending_kustomize/containerized_krm_functions.md
+++ b/site/content/en/guides/extending_kustomize/containerized_krm_functions.md
@@ -32,7 +32,8 @@ metadata:
   name: notImportantHere
   annotations:
     config.kubernetes.io/function: |
-      image: example.docker.com/my-functions/chart-inflator:0.1.6
+      container:
+        image: example.docker.com/my-functions/chart-inflator:0.1.6
 spec:
   chartName: minecraft
 ```
@@ -111,7 +112,8 @@ metadata:
   name: notImportantHere
   annotations:
     config.kubernetes.io/function: |
-      image: example.docker.com/my-functions/valueannotator:1.0.0
+      container:
+        image: example.docker.com/my-functions/valueannotator:1.0.0
 value: 'important-data'
 ```
 


### PR DESCRIPTION
Example yaml code on `Containerized KRM Functions`  is missing one line.
This yaml Doesn't work.

The correct settings are as follows:
```
# $MYAPP/annotator.yaml
apiVersion: transformers.example.co/v1
kind: ValueAnnotator
metadata:
  name: notImportantHere
  annotations:
    config.kubernetes.io/function: |
      container:
        image: example.docker.com/my-functions/valueannotator:1.0.0
value: 'important-data'
```

source: https://github.com/kubernetes-sigs/kustomize/blob/f61b075d3bd670b7bcd5d58ce13e88a6f25977f2/hack/krmFunctionBenchmark/example_tshirt/containerfn/transf.yaml