### PR TITLE
correct binaries page to remove Windows reference

### DIFF
--- a/site/content/en/installation/kustomize/binaries.md
+++ b/site/content/en/installation/kustomize/binaries.md
@@ -7,9 +7,9 @@ description: >
   Install Kustomize by downloading precompiled binaries.
 ---
 
-Binaries at various versions for linux, MacOs and Windows are published on the [releases page].
+Binaries at various versions for linux and MacOs are published on the [releases page].
 
-The following [script] detects your OS and downloads the appropriate kustomize binary to your
+The following [script] for linux or MacOs detects your OS and downloads the appropriate kustomize binary to your
 current working directory.
 
 ```bash


### PR DESCRIPTION
Despite what the opening sentence said, there is no Windows binary on the releases page (for the most recent 3releases (4.2-4.4).

More important, the offered install_kustomize.sh script is clearly *nix-only. It make no sense to have a Windows person curl and run that script, let alone pipe then to Bash (as offered in the command-line to curl/install here. (FWIW, recent versions do indeed support curl itself.)

I was torn about  adding additional information about how Windows users could at least find an installer binary for SOME kustomize versions (again, the last being 4.1 as I write), but I could see that being troublesome. Also, since that install script doesn't work, it would be useful to add clarification that Windows users would find a single kustomize.exe in the tar.gz listed for such versions--but again someone here may feel that such details aren't warranted. Indeed, if Windows support is being deprecated--perhaps for a seeming relative lack of interest--then I understand why so clarifications for Windows would be added. And that's why I propose the change here that I do.