### PR TITLE
add link to installing kustomize

### DIFF
--- a/site/content/en/guides/introduction/kustomize.md
+++ b/site/content/en/guides/introduction/kustomize.md
@@ -13,7 +13,7 @@ description:
 - Kustomize uses patches to introduce environment specific changes on an already existing standard config file without disturbing it.
 {{< /alert >}}
 
-Kustomize provides a solution for customizing Kubernetes resource configuration free from templates and DSLs.
+[Kustomize](https://kubectl.docs.kubernetes.io/installation/kustomize/) provides a solution for customizing Kubernetes resource configuration free from templates and DSLs.
 
 Kustomize lets you customize raw, template-free YAML
 files for multiple purposes, leaving the original YAML


### PR DESCRIPTION
Someone ending up on this page could think that kustomize is included in Kubernetes installations, like kubectl is (which is discussed in a sibling topic). Adding even just this one link to the resource on implementing kustomize (as installer, docker image, etc.) could help readers new to kustomize.