### PR TITLE
add missing link to configMapGenerator docs

### DIFF
--- a/site/content/en/references/kustomize/kustomization/secretgenerator/_index.md
+++ b/site/content/en/references/kustomize/kustomization/secretgenerator/_index.md
@@ -9,7 +9,7 @@ description: >
 
 Each entry in the argument list results in the creation of one Secret resource (it's a generator of N secrets).
 
-This works like the [configMapGenerator]().
+This works like the [configMapGenerator](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/configmapgenerator/).
 
 ```yaml
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
atm if you click the link you stay on the same site.