### PR TITLE
Update _index.md

### DIFF
--- a/site/content/en/references/kustomize/builtins/_index.md
+++ b/site/content/en/references/kustomize/builtins/_index.md
@@ -757,25 +757,17 @@ helmChartInflationGenerator:
 
 #### Arguments
 
-> ChartName string
+> Name string
 >
-> ChartVersion string
+> Version string
 >
-> ChartRepoURL string
+> Repo string
 >
-> ChartHome string
->
-> ChartRepoName string
->
-> HelmBin string
->
-> HelmHome string
->
-> Values string
+> valuesFile string
 >
 > ReleaseName string
 >
-> ReleaseNamespace string
+> Namespace string
 >
 > ExtraArgs []string
 
@@ -786,14 +778,10 @@ helmChartInflationGenerator:
 > kind: HelmChartInflationGenerator
 > metadata:
 >   name: myMap
-> chartName: minecraft
-> chartRepoUrl: https://kubernetes-charts.storage.googleapis.com
-> chartVersion: v1.2.0
-> helmBin: /usr/bin/helm
-> helmHome: /tmp/helmHome
+> name: minecraft
+> repo: https://kubernetes-charts.storage.googleapis.com
+> version: v1.2.0
 > releaseName: test
-> releaseNamespace: testNamespace
-> values: values.yaml
-> extraArgs:
-> - --include-crds
-> ```
+> namespace: testNamespace
+> valuesFile: values.yaml
+> IncludeCRDs: true

--- a/site/content/en/references/kustomize/builtins/_index.md
+++ b/site/content/en/references/kustomize/builtins/_index.md
@@ -727,49 +727,61 @@ and rendering of a helm chart.
 
 Each entry can have following fields:
 
-- `chartName`: The name of the chart that you want to use.
-- `chartRepoUrl`: [Optional] The URL of the repository which contains the chart. If
+- `name`: The name of the chart that you want to use.
+- `repo`: [Optional] The URL of the repository which contains the chart. If
   this is provided, the generator will try to fetch remote charts. Otherwise it will
   try to load local chart in `chartHome`.
-- `chartVersion`: [Optional] Version of the chart. Will use latest version
-  if this is omitted.
 - `chartHome`: [Optional] Provide the path to the parent directory for local chart.
-- `chartRelease`: [Optional] The name of the repo where to find the chart.
-- `values`: [Optional] A path to the values file.
+- `version`: [Optional] Version of the chart. Will use latest version
+  if this is omitted.
 - `releaseName`: [Optional] The release name that will be set in the chart.
-- `releaseNamespace`: [Optional] The namespace which will be used by `--namespace`
+- `namespace`: [Optional] The namespace which will be used by `--namespace`
   flag in `helm template` command.
-- `helmBin`: [Optional] Path to helm binary. Default is `helm`.
-- `helmHome`: [Optional] Path to helm home directory.
-- `extraArgs`: [Optional] A list of additional argumetns that will be passed into helm
-  template command.
-
+- `valuesFile`: [Optional] A path to the values file.
+- `valuesInline`: holds value mappings specified directly, rather than in a separate file.
+- `valuesMerge`: specifies how to treat `valuesInline` with respect to Values.
+   Legal values: 'merge', 'override', 'replace'. Defaults to 'override'.
+- `includeCRDs`: specifies if Helm should also generate CustomResourceDefinitions.
+   Defaults to 'false'.  
+- `configHome`: [Optional] The value that kustomize should pass to helm via
+  `HELM_CONFIG_HOME` environment variable.
+   If omitted, `{tmpDir}/helm` is used, where `{tmpDir}` is some temporary.
 ```
 helmChartInflationGenerator:
-- chartName: minecraft
-  chartRepoUrl: https://kubernetes-charts.storage.googleapis.com
-  chartVersion: v1.2.0
+- name: minecraft
+  repo: https://kubernetes-charts.storage.googleapis.com
+  version: v1.2.0
   releaseName: test
-  releaseNamespace: testNamespace
+  namespace: testNamespace
+  valuesFile: values.yaml
 ```
 
 ### Usage via `generators` field
 
 #### Arguments
 
-> Name string
+> name string
 >
-> Version string
+> version string
 >
-> Repo string
+> repo string
+>
+> releaseName string
+>
+> namespace string
 >
 > valuesFile string
->
-> ReleaseName string
->
-> Namespace string
->
-> ExtraArgs []string
+> 
+> valuesInline map[string]interface{}
+> 
+> valuesMerge string
+> 
+> includeCRDs bool
+> 
+> configHome: string
+
+
+
 
 #### Example
 


### PR DESCRIPTION
The `HelmChartInflationGenerator` documentation for the `builtin` API is not updated.
Updating the last behavior.

```
apiVersion: builtin
kind: HelmChartInflationGenerator
metadata:
  name: myMap
name: minecraft
repo: https://kubernetes-charts.storage.googleapis.com
version: v1.2.0
releaseName: test
namespace: testNamespace
valuesFile: values.yaml
IncludeCRDs: true
```