### PR TITLE
add file-based configuration for netlify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ dyctl
 .idea/
 *.iml
 
+# Compiled site
+publishedSite/
+
 # go artifacts
 cover.out
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   base = "site/"
   command = "hugo"
-  publish = "publishedSite"
+  publish = "../publishedSite"
 
 [context.production.environment]
   HUGO_VERSION = "0.92.2"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 [build]
+  base = "site/"
   command = "hugo"
   publish = "publishedSite"
 

--- a/site/config.toml
+++ b/site/config.toml
@@ -1,7 +1,7 @@
 baseURL = "https://kubectl.docs.kubernetes.io"
 title = "SIG CLI"
 
-publishDir = "../docs"
+publishDir = "publishedSite"
 
 enableRobotsTXT = true
 

--- a/site/config.toml
+++ b/site/config.toml
@@ -1,7 +1,7 @@
 baseURL = "https://kubectl.docs.kubernetes.io"
 title = "SIG CLI"
 
-publishDir = "publishedSite"
+publishDir = "../publishedSite"
 
 enableRobotsTXT = true
 

--- a/site/content/en/contributing/docs/_index.md
+++ b/site/content/en/contributing/docs/_index.md
@@ -40,7 +40,7 @@ Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
 
 Once you've verified that your changes look good using the local Hugo server, compile the HTML to be committed.
 
-1. Commit the changes to both the `site/` folder.  Do not commit anything from the `publishedSite/` folder
+1. Commit the changes to the `site/` folder.  Do not commit anything from the `publishedSite/` folder
 
 2. Open a PR.
 

--- a/site/content/en/contributing/docs/_index.md
+++ b/site/content/en/contributing/docs/_index.md
@@ -40,33 +40,11 @@ Web Server is available at http://localhost:1313/ (bind address 127.0.0.1)
 
 Once you've verified that your changes look good using the local Hugo server, compile the HTML to be committed.
 
-1. Run the `hugo` command. This compiles the files under `site` into HTML, which it puts in the `docs` folder:
+1. Commit the changes to both the `site/` folder.  Do not commit anything from the `publishedSite/` folder
 
-```shell script
-cd site/
-hugo
-```
+2. Open a PR.
 
-```shell script
-                   | EN  
--------------------+-----
-  Pages            | 99  
-  Paginator pages  |  0  
-  Non-page files   |  0  
-  Static files     | 47  
-  Processed images |  0  
-  Aliases          |  2  
-  Sitemaps         |  1  
-  Cleaned          |  0  
-```
-
-
-
-2. Commit the changes to both the `site/` and `docs/` folders.
-
-3. Open a PR.
-
-4. Once status checks run on your PR, look for the `deploy/netlify` status check, and click the `Details` link to verify your change on Netlify.
+3. Once status checks run on your PR, look for the `deploy/netlify` status check, and click the `Details` link to verify your change on Netlify.
 
 ![Netlify Preview PR Status Image][pr-preview]
 

--- a/site/netlify.toml
+++ b/site/netlify.toml
@@ -1,0 +1,9 @@
+[build]
+  command = "hugo"
+  publish = "publishedSite"
+
+[context.production.environment]
+  HUGO_VERSION = "0.92.2"
+
+[context.deploy-preview.environment]
+  HUGO_VERSION = "0.92.2"


### PR DESCRIPTION
This PR aims to tackle https://github.com/kubernetes-sigs/kustomize/issues/4393

With the added netlify.toml file:

- Changes in the site folder rebuild the site automatically
- Production and Preview site can be configured to use a different hugo version, quite handy for upgrades to hugo version

Once this PR is merged the `docs` folder should not be in use any more and I think it would be good to remove it in another PR.