### PR TITLE
site/kustomize: fix resource hyperlink to base

### DIFF
--- a/site/content/en/references/kustomize/kustomization/bases/_index.md
+++ b/site/content/en/references/kustomize/kustomization/bases/_index.md
@@ -11,7 +11,7 @@ description: >
 The `bases` field was deprecated in v2.1.0
 {{% /pageinfo %}}
 
-Move entries into the [resources](/references/kustomize/resource)
+Move entries into the [resources](/references/kustomize/kustomization/resource)
 field.  This allows bases - which are still a
 [central concept](/references/kustomize/glossary#base) - to be
 ordered relative to other input resources.


### PR DESCRIPTION
This change fixes the resources hyperlink in the kustomize kustomization [bases documentation](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/bases/).