### PR TITLE
fix broken links in guides

### DIFF
--- a/site/content/en/guides/config_management/container_images.md
+++ b/site/content/en/guides/config_management/container_images.md
@@ -62,5 +62,5 @@ Some of things that can be done with images:
 - Setting a Tag from an Environment Variable
 
 {{% alert color="success" title="Command / Examples" %}}
-Check out the [reference](/references/kustomize/images/) for commands and examples for `images`
+Check out the [reference](/references/kustomize/kustomization/images/) for commands and examples for `images`
 {{% /alert %}}

--- a/site/content/en/guides/config_management/labels_annotations.md
+++ b/site/content/en/guides/config_management/labels_annotations.md
@@ -99,7 +99,7 @@ spec:
 ```
 
 {{% alert color="success" title="Command / Examples" %}}
-Check out the [reference](/references/kustomize/commonlabels/) for commands and examples for `setting labels`
+Check out the [reference](/references/kustomize/kustomization/commonlabels/) for commands and examples for `setting labels`
 {{% /alert %}}
 
 ### Propagating Labels to Selectors
@@ -122,7 +122,7 @@ Labeling Workload Resources makes it simpler to query Pods - e.g. for the purpos
 
 ## Setting Annotations 
 
-Setting Annotations is very similar to setting labels as seen above. Check out the [reference](/references/kustomize/commonannotations/) for commands and examples.
+Setting Annotations is very similar to setting labels as seen above. Check out the [reference](/references/kustomize/kustomization/commonannotations/) for commands and examples.
 
 {{< alert color="warning" title="Propagating Annotations" >}}
 In addition to updating the annotations for each Resource, any fields that contain ObjectMeta

--- a/site/content/en/guides/config_management/namespaces_names.md
+++ b/site/content/en/guides/config_management/namespaces_names.md
@@ -35,7 +35,7 @@ This sets the namespace for both generated Resources (e.g. ConfigMaps and Secret
 Resources.
 
 {{% alert color="success" title="Command / Examples" %}}
-Check out the [reference](/references/kustomize/namespace/) for commands and examples for `setting namespace`
+Check out the [reference](/references/kustomize/kustomization/namespace/) for commands and examples for `setting namespace`
 {{% /alert %}}
 
 **Example:** Set the `namespace` specified in the `kustomization.yaml` on the namespaced Resources.
@@ -102,7 +102,7 @@ spec:
 Setting the namespace will override the namespace on Resources if it is already set.
 
 {{% alert color="success" title="Command / Examples" %}}
-Check out the [nameprefix](/references/kustomize/nameprefix/) / [namesuffix](/references/kustomize/namesuffix/) for commands and examples for `setting nameprefix / namesuffix` to kubernetes resources
+Check out the [nameprefix](/references/kustomize/kustomization/nameprefix/) / [namesuffix](/references/kustomize/kustomization/namesuffix/) for commands and examples for `setting nameprefix / namesuffix` to kubernetes resources
 {{% /alert %}}
 
 

--- a/site/content/en/guides/config_management/secrets_configmaps.md
+++ b/site/content/en/guides/config_management/secrets_configmaps.md
@@ -36,7 +36,7 @@ changes.  See [Rollouts](#rollouts) for more on this.
 ### ConfigMapsGenerator
 
 {{% alert color="success" title="Command / Examples" %}}
-Check out the [reference](/references/kustomize/configmapgenerator/) for commands and examples for `ConfigMapsGenerator`
+Check out the [reference](/references/kustomize/kustomization/configmapgenerator/) for commands and examples for `ConfigMapsGenerator`
 {{% /alert %}}
 
 Consider we have to generate ConfigMap from a preset values stored in `.properties` file. One can make use
@@ -72,7 +72,7 @@ metadata:
 
 ### SecretGenerator
 {{% alert color="success" title="Command / Examples" %}}
-Check out the [reference](/references/kustomize/secretgenerator/) for commands and examples
+Check out the [reference](/references/kustomize/kustomization/secretgenerator/) for commands and examples
 for `SecretGenerator`
 {{% /alert %}}
 


### PR DESCRIPTION

fix broken links in guides which points to references/examples which where moved by this commit (1 year ago!):

https://github.com/kubernetes-sigs/cli-experimental/commit/8e1ef9f7779d172dc6319e616007a396c9d5f973