### PR TITLE
Escape the backslash in docs

### DIFF
--- a/site/content/en/references/kustomize/kustomization/replacements/_index.md
+++ b/site/content/en/references/kustomize/kustomization/replacements/_index.md
@@ -188,7 +188,7 @@ metadata:
 
 We can express our path:
 
-1. With a '\': `metadata.annotations.config\.kubernetes\.io/local-config`
+1. With a '\\': `metadata.annotations.config\.kubernetes\.io/local-config`
 
 2. With '[]': `metadata.annotations.[config.kubernetes.io/local-config]`
 


### PR DESCRIPTION
Missing escape for the escape (backslash) char in docs.