### PR TITLE
Update copyright to match k8s docs

### DIFF
--- a/site/config.toml
+++ b/site/config.toml
@@ -84,7 +84,8 @@ weight = 2
 # Everything below this are Site Params
 
 [params]
-copyright = "SIG CLI | Documentation Distributed under CC BY 4.0 | "
+copyright_k8s = "The Kubernetes Authors"
+copyright_linux =  "Copyright © 2020 The Linux Foundation ®."
 
 # First one is picked as the Twitter card image if not set on page.
 # images = ["images/project-illustration.png"]

--- a/site/i18n/en.toml
+++ b/site/i18n/en.toml
@@ -1,0 +1,8 @@
+# i18n strings for the English (main) site.
+# NOTE: Please keep the entries in alphabetical order when editing
+
+[main_copyright_notice]
+other = """The Linux Foundation &reg;. All rights reserved. The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see our <a href="https://www.linuxfoundation.org/trademark-usage" class="light-text">Trademark Usage page</a>"""
+
+[main_documentation_license]
+other = """The Kubernetes Authors | Documentation Distributed under <a href="https://git.k8s.io/website/LICENSE" class="light-text">CC BY 4.0</a>"""

--- a/site/layouts/partials/footer.html
+++ b/site/layouts/partials/footer.html
@@ -1,0 +1,29 @@
+{{ $links := .Site.Params.links }}
+<footer class="bg-dark row d-print-none" style="min-height: initial">
+  <div class="container-fluid mx-sm-5">
+    <div class="row">
+      <div class="col-12 text-center mt-3 mb-3">
+        {{ with .Site.Params.copyright_k8s }}<small class="text-white">&copy; {{ now.Year}} {{ T "main_documentation_license" | safeHTML }}</small>{{ end }}
+        <br />
+        {{ with .Site.Params.copyright_linux }}<small class="text-white">Copyright &copy; {{ now.Year }} {{ T "main_copyright_notice" | safeHTML }}</small>{{ end }}
+        <br />
+        <small class="text-white">ICP license: 京ICP备17074266号-3</small>
+        {{ with .Site.Params.privacy_policy }}<small class="ml-1"><a href="{{ . }}" target="_blank" rel="noopener">{{ T "footer_privacy_policy" }}</a></small>{{ end }}
+        {{ if not .Site.Params.ui.footer_about_disable }}
+        {{ with .Site.GetPage "about" }}<p class="mt-2"><a href="{{ .RelPermalink }}">{{ .Title }}</a></p>{{ end }}
+        {{ end }}
+      </div>
+    </div>
+  </div>
+</footer>
+{{ define "footer-links-block" }}
+<ul class="list-inline mb-0 ">
+  {{ range . }}
+  <li class="list-inline-item mx-2 h3" data-toggle="tooltip" data-placement="top" title="{{ .name }}" aria-label="{{ .name }}">
+    <a class="text-white" target="_blank" rel="noopener" href="{{ .url }}" aria-label="{{ .name }}">
+      <i class="{{ .icon }}"></i>
+    </a>
+  </li>
+  {{ end }}
+</ul>
+{{ end }}


### PR DESCRIPTION
As per a [slack conversation](https://kubernetes.slack.com/archives/C1J0BPD2M/p1651863457951179), we are updating the copyright text to match [kubernetes.io](https://kubernetes.io). I've added some screenshots of the new copyright in multiple responsive sizes below:

Small
<img width="433" alt="s" src="https://user-images.githubusercontent.com/407228/167937211-3285e200-fdb7-48ff-a2df-ace71b230ac2.png">

Medium
<img width="975" alt="m" src="https://user-images.githubusercontent.com/407228/167937188-7a797318-ae24-42be-a605-b9021e72c7eb.png">

Large
<img width="1426" alt="l" src="https://user-images.githubusercontent.com/407228/167937204-3c0a4938-c8ce-47f6-939a-1ec5f020fdbf.png">