### PR TITLE
Slightly modified the `curl` command that install's kustomize binary

### DIFF
--- a/site/content/en/installation/kustomize/binaries.md
+++ b/site/content/en/installation/kustomize/binaries.md
@@ -13,7 +13,7 @@ The following [script] detects your OS and downloads the appropriate kustomize b
 current working directory.
 
 ```bash
-curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
+curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -
 ```
 
 **This script doesn't work for ARM architecture.** If you want to install ARM binaries, please


### PR DESCRIPTION
Removed the extra space and added `-` after bash!

From:
```bash
curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
```
To:
```bash
curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash -
```