### PR TITLE
Fix repeated typo in documentation examples

### DIFF
--- a/site/content/en/references/kubectl/kustomize/_index.md
+++ b/site/content/en/references/kubectl/kustomize/_index.md
@@ -30,7 +30,7 @@ spec:
   template:
     containers:
       - name: the-container
-        image: registry/conatiner:latest
+        image: registry/container:latest
 ```
 
 ```yaml
@@ -60,6 +60,6 @@ spec:
   replicas: 5
   template:
     containers:
-    - image: registry/conatiner:latest
+    - image: registry/container:latest
       name: the-container
 ```

--- a/site/content/en/references/kustomize/kustomization/namespace/_index.md
+++ b/site/content/en/references/kustomize/kustomization/namespace/_index.md
@@ -26,7 +26,7 @@ spec:
   template:
     containers:
       - name: the-container
-        image: registry/conatiner:latest
+        image: registry/container:latest
 ```
 
 ```yaml
@@ -53,6 +53,6 @@ spec:
   replicas: 5
   template:
     containers:
-    - image: registry/conatiner:latest
+    - image: registry/container:latest
       name: the-container
 ```

--- a/site/content/en/references/kustomize/kustomization/namesuffix/_index.md
+++ b/site/content/en/references/kustomize/kustomization/namesuffix/_index.md
@@ -26,7 +26,7 @@ spec:
   template:
     containers:
       - name: the-container
-        image: registry/conatiner:latest
+        image: registry/container:latest
 ```
 
 ```yaml
@@ -52,6 +52,6 @@ spec:
   replicas: 5
   template:
     containers:
-    - image: registry/conatiner:latest
+    - image: registry/container:latest
       name: the-container
 ```

--- a/site/content/en/references/kustomize/kustomization/replicas/_index.md
+++ b/site/content/en/references/kustomize/kustomization/replicas/_index.md
@@ -58,7 +58,7 @@ spec:
   template:
     containers:
       - name: the-container
-        image: registry/conatiner:latest
+        image: registry/container:latest
 ```
 
 ```yaml
@@ -86,5 +86,5 @@ spec:
   template:
     containers:
       - name: the-container
-        image: registry/conatiner:latest
+        image: registry/container:latest
 ```


### PR DESCRIPTION
I believe "container" is intended, not "conatiner".