### PR TITLE
docs: remove warning about ARM support for Kustomize install script

### DIFF
--- a/site/content/en/installation/kustomize/binaries.md
+++ b/site/content/en/installation/kustomize/binaries.md
@@ -16,8 +16,5 @@ current working directory.
 curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash
 ```
 
-**This script doesn't work for ARM architecture.** If you want to install ARM binaries, please
-go to the release page to find the URL.
-
 [releases page]: https://github.com/kubernetes-sigs/kustomize/releases
 [script]: https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh


### PR DESCRIPTION
Removes warning about ARM support for Kustomize install script as it is now supported.
Reference: https://github.com/kubernetes-sigs/kustomize/pull/4619.