### PR TITLE
chore: add `restartPolicy` into sample because this is required prope…

### DIFF
--- a/site/content/en/references/kustomize/kustomization/replacements/_index.md
+++ b/site/content/en/references/kustomize/kustomization/replacements/_index.md
@@ -215,6 +215,7 @@ metadata:
 spec:
   template:
     spec:
+      restartPolicy: OnFailure
       containers:
         - image: myimage
           name: hello


### PR DESCRIPTION
##### background

When copy and apply sample code, this error message displayed.

```
The Job "local-hello-v1" is invalid: spec.template.spec.restartPolicy: Required value: valid values: "OnFailure", "Never"
```