### PR TITLE
Fix invalid Deployment definitions in kubectl apply/kustomize reference

### DIFF
--- a/site/content/en/references/kubectl/apply/_index.md
+++ b/site/content/en/references/kubectl/apply/_index.md
@@ -20,9 +20,10 @@ metadata:
 spec:
   replicas: 5
   template:
-    containers:
-      - name: the-container
-        image: registry/container:latest
+    spec:
+      containers:
+        - name: the-container
+          image: registry/container:latest
 ```
 
 ```bash
@@ -70,9 +71,10 @@ metadata:
 spec:
   replicas: 5
   template:
-    containers:
-      - name: the-container
-        image: registry/container:latest
+    spec:
+      containers:
+        - name: the-container
+          image: registry/container:latest
 ```
 
 Users run Apply on directories containing `kustomization.yaml` files using `-k` or on raw

--- a/site/content/en/references/kubectl/kustomize/_index.md
+++ b/site/content/en/references/kubectl/kustomize/_index.md
@@ -28,9 +28,10 @@ metadata:
 spec:
   replicas: 5
   template:
-    containers:
-      - name: the-container
-        image: registry/container:latest
+    spec:
+      containers:
+        - name: the-container
+          image: registry/container:latest
 ```
 
 ```yaml
@@ -59,7 +60,8 @@ metadata:
 spec:
   replicas: 5
   template:
-    containers:
-    - image: registry/container:latest
-      name: the-container
+    spec:
+      containers:
+        - name: the-container
+          image: registry/container:latest
 ```

--- a/site/content/en/references/kustomize/kustomization/nameprefix/_index.md
+++ b/site/content/en/references/kustomize/kustomization/nameprefix/_index.md
@@ -22,9 +22,10 @@ metadata:
 spec:
   replicas: 5
   template:
-    containers:
-      - name: the-container
-        image: registry/container:latest
+    spec:
+      containers:
+        - name: the-container
+          image: registry/container:latest
 ```
 
 ```yaml
@@ -49,9 +50,10 @@ metadata:
 spec:
   replicas: 5
   template:
-    containers:
-    - image: registry/container:latest
-      name: the-container
+    spec:
+      containers:
+        - name: the-container
+          image: registry/container:latest
 ```
 
 {{< alert color="success" title="References" >}}

--- a/site/content/en/references/kustomize/kustomization/namespace/_index.md
+++ b/site/content/en/references/kustomize/kustomization/namespace/_index.md
@@ -24,9 +24,10 @@ metadata:
 spec:
   replicas: 5
   template:
-    containers:
-      - name: the-container
-        image: registry/container:latest
+    spec:
+      containers:
+        - name: the-container
+          image: registry/container:latest
 ```
 
 ```yaml
@@ -52,7 +53,8 @@ metadata:
 spec:
   replicas: 5
   template:
-    containers:
-    - image: registry/container:latest
-      name: the-container
+    spec:
+      containers:
+        - name: the-container
+          image: registry/container:latest
 ```

--- a/site/content/en/references/kustomize/kustomization/namesuffix/_index.md
+++ b/site/content/en/references/kustomize/kustomization/namesuffix/_index.md
@@ -24,9 +24,10 @@ metadata:
 spec:
   replicas: 5
   template:
-    containers:
-      - name: the-container
-        image: registry/container:latest
+    spec:
+      containers:
+        - name: the-container
+          image: registry/container:latest
 ```
 
 ```yaml
@@ -51,7 +52,8 @@ metadata:
 spec:
   replicas: 5
   template:
-    containers:
-    - image: registry/container:latest
-      name: the-container
+    spec:
+      containers:
+        - name: the-container
+          image: registry/container:latest
 ```

--- a/site/content/en/references/kustomize/kustomization/replicas/_index.md
+++ b/site/content/en/references/kustomize/kustomization/replicas/_index.md
@@ -56,9 +56,10 @@ metadata:
 spec:
   replicas: 5
   template:
-    containers:
-      - name: the-container
-        image: registry/container:latest
+    spec:
+      containers:
+        - name: the-container
+          image: registry/container:latest
 ```
 
 ```yaml
@@ -84,7 +85,8 @@ metadata:
 spec:
   replicas: 10
   template:
-    containers:
-      - name: the-container
-        image: registry/container:latest
+    spec:
+      containers:
+        - name: the-container
+          image: registry/container:latest
 ```


### PR DESCRIPTION
`kubectl apply` and `kustomize` examples contain invalid yaml