### PR TITLE
doc: use dl.k8s.io, not kubernetes-release bucket

### DIFF
--- a/site/content/en/installation/kubectl/binaries.md
+++ b/site/content/en/installation/kubectl/binaries.md
@@ -32,15 +32,15 @@ description: >
 2. Download the latest release with the command:
 
     ```bash
-    curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/$os/kubectl"
+    curl -LO "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/$os/kubectl"
     ```
 
-    To download a specific version, replace the `$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)` portion of the command with the specific version.
+    To download a specific version, replace the `$(curl -sL https://dl.k8s.io/release/stable.txt)` portion of the command with the specific version.
 
     For example, to download version v1.19.0 on Linux, type:
     
     ```bash
-    curl -LO "https://storage.googleapis.com/kubernetes-release/release/v1.19.0/bin/$os/kubectl"
+    curl -LO "https://dl.k8s.io/release/v1.19.0/bin/$os/kubectl"
     ```
 
 3. Make the kubectl binary executable.


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
There are still references to https://storage.googleapis.com/kubernetes-release instead of https://dl.k8s.io/

dl.k8s.io is the correct advertised download host and will eventually move to be fastly shielding a fully community-owned bucket

ref: https://github.com/kubernetes/k8s.io/issues/2396