### PR TITLE
docs: types.PatchTarget broken link repalced with types.Selector

### DIFF
--- a/site/content/en/references/kustomize/builtins/_index.md
+++ b/site/content/en/references/kustomize/builtins/_index.md
@@ -32,7 +32,6 @@ complete argument specification.
 [types.Selector]: https://github.com/kubernetes-sigs/kustomize/tree/master/api/types/selector.go
 [types.Replica]: https://github.com/kubernetes-sigs/kustomize/tree/master/api/types/replica.go
 [types.PatchStrategicMerge]: https://github.com/kubernetes-sigs/kustomize/tree/master/api/types/patchstrategicmerge.go
-[types.PatchTarget]: https://github.com/kubernetes-sigs/kustomize/tree/master/api/types/patchtarget.go
 [image.Image]: https://github.com/kubernetes-sigs/kustomize/tree/master/api/types/image.go
 
 ## _AnnotationTransformer_
@@ -392,7 +391,7 @@ patchesJson6902:
 
 #### Arguments
 
-> Target [types.PatchTarget]
+> Target [types.Selector]
 >
 > Path   string
 >


### PR DESCRIPTION
This fixes a broken link to patchtarget.go. As far as I can tell from the kustomize repo, Target is now represented with types.Selector instead of types.PatchTarget (https://github.com/kubernetes-sigs/kustomize/blob/0add0f95e2d7be992801411bb1851c528b9831dd/api/types/patch.go#L20). Looks like types.PatchTarget was replaced with types.Selector which accepts a GVKN-style target in commit https://github.com/kubernetes-sigs/kustomize/commit/3b79944190dfd25982ef2891c289b9c8235e0ee9