### PR TITLE
docs: add syntax hint for multiple sources

### DIFF
--- a/site/content/en/references/kustomize/kustomization/replacements/_index.md
+++ b/site/content/en/references/kustomize/kustomization/replacements/_index.md
@@ -256,7 +256,10 @@ resources:
 - job.yaml
 
 replacements:
+# additional sources/paths can be added in a list
+
 - path: my-replacement.yaml
+# - path: ...
 - source:
     kind: Secret
     name: my-secret
@@ -266,22 +269,25 @@ replacements:
       kind: Job
     fieldPaths:
     - spec.template.spec.containers.[name=hello].env.[name=SECRET_TOKEN].value
+# - source: ...
 ```
 
 `my-replacement.yaml`
 ```yaml
-source:
-  kind: Pod
-  name: my-pod
-  fieldPath: spec.restartPolicy
-targets:
-- select:
-    name: hello
-    kind: Job
-  fieldPaths:
-  - spec.template.spec.restartPolicy
-  options:
-    create: true
+- source:
+    kind: Pod
+    name: my-pod
+    fieldPath: spec.restartPolicy
+  targets:
+  - select:
+      name: hello
+      kind: Job
+    fieldPaths:
+    - spec.template.spec.restartPolicy
+    options:
+      create: true
+# additional sources can be added in a list
+# - source: ...
 ```
 
 The output of `kustomize build` will be:


### PR DESCRIPTION
Replacements can consider multiple sources. This is just a proposal on how to add this into the documentation.