### PR TITLE
Update source.md with correct git clone command for public access, else git clone fails each time

### DIFF
--- a/site/content/en/installation/kustomize/source.md
+++ b/site/content/en/installation/kustomize/source.md
@@ -32,7 +32,8 @@ unset GOPATH
 unset GO111MODULES
 
 # clone the repo
-git clone git@github.com:kubernetes-sigs/kustomize.git
+git clone https://github.com/kubernetes-sigs/kustomize.git
+
 # get into the repo root
 cd kustomize
 


### PR DESCRIPTION
As normal user don't have access to make changes, clone command need to use correct way to clone git repo. 

**Correct way**:
Else clone will fail for most of non "kubernetes-sigs" repo users.
   git clone https://github.com/kubernetes-sigs/kustomize.git


_Wrong way_:
git clone git@github.com:kubernetes-sigs/kustomize.git
  git@github.com: Permission denied (publickey).
  fatal: Could not read from remote repository.
 