### PR TITLE
replacements:  change the unrendered `:heavy_check_mark:` for the unicode ✔️ 

### DIFF
--- a/site/content/en/references/kustomize/kustomization/replacements/_index.md
+++ b/site/content/en/references/kustomize/kustomization/replacements/_index.md
@@ -88,14 +88,14 @@ replacements:
 
 | Field       | Required| Description | Default |
 | -----------: | :----:| ----------- | ---- |
-| `source`| :heavy_check_mark: | The source of the value |
-| `target`|:heavy_check_mark: | The N fields to write the value to |
+| `source`| ✔️ | The source of the value |
+| `target`| ✔️ | The N fields to write the value to |
 | `group` | | The group of the referent |
 | `version`|  | The version of the referent
 |`kind` | |The kind of the referent
 |`name` | |The name of the referent
 |`namespace`|  |The namespace of the referent
-|`select` |:heavy_check_mark: |Include objects that match this
+|`select` | ✔️ |Include objects that match this
 |`reject`| |Exclude objects that match this
 |`fieldPath`|  |The structured path to the source value | `metadata.name`
 |`fieldPaths`|  |The structured path(s) to the target nodes | `metadata.name`


### PR DESCRIPTION
The source code contains `:heavy_check_mark:` which appear unrendered on the HTML. I'm assuming the intention was to show the ✔️  [U+2714 Heavy Check Mark](https://www.compart.com/en/unicode/U+2714)


The documentation page in question is https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/replacements/#field-descriptions
![image](https://github.com/kubernetes-sigs/cli-experimental/assets/58676/c8c73599-67be-4229-8c7e-fce218879651)
