### PR TITLE
Fix typo in example Bash command

### DIFF
--- a/site/content/en/guides/example/multi_base.md
+++ b/site/content/en/guides/example/multi_base.md
@@ -26,7 +26,7 @@ that is just a single pod.
 Define a place to work:
 
 ```bash
-DEMO_HOME = $(mktemp -d)
+DEMO_HOME=$(mktemp -d)
 ```
 
 ## `/base`


### PR DESCRIPTION
It does not work with spaces.