### PR TITLE
Update documentation for localizing absolute paths

### DIFF
--- a/site/content/en/references/kustomize/cmd/localize/_index.md
+++ b/site/content/en/references/kustomize/cmd/localize/_index.md
@@ -170,8 +170,7 @@ The command also localizes the following deprecated fields:
 * `patchesJson6902`
 
 ### Notes
-* [absolute]: The alpha version of this command does not handle and
-throws an error for absolute paths.
+* [absolute]: Absolute paths are replaced by paths relative to the kustomization root.
 <br></br>
 
 * [build]: This command may not catch `build` errors in the kustomization, as


### PR DESCRIPTION
Related to: https://github.com/kubernetes-sigs/kustomize/issues/5275 

With PR https://github.com/kubernetes-sigs/kustomize/pull/5294, absolute paths can now be localized, but are converted to relative paths of the kustomization root in the process. This PR adds this as note to the documentation.

**Note:** this PR depends on https://github.com/kubernetes-sigs/kustomize/pull/5294 being merged