### PR TITLE
Correct typo from 'Kubenetes' to 'Kubernetes'

### DIFF
--- a/site/content/en/references/kubectl/scale/_index.md
+++ b/site/content/en/references/kubectl/scale/_index.md
@@ -4,7 +4,7 @@ linkTitle: "scale"
 weight: 1
 type: docs
 description: >
-    Scaling Kubenetes Resources
+    Scaling Kubernetes Resources
 ---
 
 Set a new size for a Deployment, ReplicaSet, Replication Controller, or StatefulSet.


### PR DESCRIPTION
## Description

Correct typo from 'Kubenetes' to 'Kubernetes'.