### PR TITLE
Use lowercases for some terms in kubectl.md

### DIFF
--- a/site/content/en/guides/introduction/kubectl.md
+++ b/site/content/en/guides/introduction/kubectl.md
@@ -1,59 +1,59 @@
 ---
-title: "Kubectl"
-linkTitle: "Kubectl"
+title: "kubectl"
+linkTitle: "kubectl"
 weight: 1
 type: docs
 description: >
-    Introduction to Kubectl
+    Introduction to kubectl
 ---
 
 {{< alert color="success" title="TL;DR" >}}
-- Kubectl is the Kubernetes cli
-- Kubectl provides a swiss army knife of functionality for working with Kubernetes clusters
-- Kubectl may be used to deploy and manage applications on Kubernetes
-- Kubectl may be used for scripting and building higher-level frameworks
+- kubectl is the Kubernetes cli
+- kubectl provides a swiss army knife of functionality for working with Kubernetes clusters
+- kubectl may be used to deploy and manage applications on Kubernetes
+- kubectl may be used for scripting and building higher-level frameworks
 {{< /alert >}}
 
-Kubectl is the Kubernetes cli version of a swiss army knife, and can do many things.
+kubectl is the Kubernetes cli version of a swiss army knife, and can do many things.
 
-While this Book is focused on using Kubectl to declaratively manage Applications in Kubernetes, it
-also covers other Kubectl functions.
+While this Book is focused on using kubectl to declaratively manage applications in Kubernetes, it
+also covers other kubectl functions.
 
 ## Command Families
 
-Most Kubectl commands typically fall into one of a few categories:
+Most kubectl commands typically fall into one of a few categories:
 
 | Type                                   | Used For                   | Description                                        |
 |----------------------------------------|----------------------------|----------------------------------------------------|
-| Declarative Resource Management        | Deployment and Operations (e.g. GitOps)   | Declaratively manage Kubernetes Workloads using Resource Config     |
-| Imperative Resource Management         | Development Only           | Run commands to manage Kubernetes Workloads using Command Line arguments and flags |
-| Printing Workload State | Debugging  | Print information about Workloads |
-| Interacting with Containers | Debugging  | Exec, Attach, Cp, Logs |
-| Cluster Management | Cluster Ops | Drain and Cordon Nodes |
+| Declarative Resource Management        | Deployment and operations (e.g. GitOps)   | Declaratively manage Kubernetes workloads using resource configuration     |
+| Imperative Resource Management         | Development only           | Run commands to manage Kubernetes workloads using Command Line arguments and flags |
+| Printing Workload State | Debugging  | Print information about workloads |
+| Interacting with Containers | Debugging  | Exec, attach, cp, logs |
+| Cluster Management | Cluster operations | Drain and cordon nodes |
 
 ## Declarative Application Management
 
-The preferred approach for managing Resources is through
-declarative files called Resource Config used with the Kubectl *Apply* command.
+The preferred approach for managing resources is through
+declarative files called resource configuration used with the kubectl *Apply* command.
 This command reads a local (or remote) file structure and modifies cluster state to
 reflect the declared intent.
 
 {{< alert color="success" title="Apply" >}}
-Apply is the preferred mechanism for managing Resources in a Kubernetes cluster.
+Apply is the preferred mechanism for managing resources in a Kubernetes cluster.
 {{< /alert >}}
 
-## Printing state about Workloads
+## Printing State about Workloads
 
-Users will need to view Workload state.
+Users will need to view workload state.
 
-- Printing summarize state and information about Resources
-- Printing complete state and information about Resources
-- Printing specific fields from Resources
-- Query Resources matching labels
+- Printing summarize state and information about resources
+- Printing complete state and information about resources
+- Printing specific fields from resources
+- Query resources matching labels
 
 ## Debugging Workloads
 
-Kubectl supports debugging by providing commands for:
+kubectl supports debugging by providing commands for:
 
 - Printing Container logs
 - Printing cluster events
@@ -62,21 +62,20 @@ Kubectl supports debugging by providing commands for:
 
 ## Cluster Management
 
-On occasion, users may need to perform operations to the Nodes of cluster.  Kubectl supports
-commands to drain Workloads from a Node so that it can be decommission or debugged.
+On occasion, users may need to perform operations to the nodes of cluster. kubectl supports
+commands to drain workloads from a node so that it can be decommissioned or debugged.
 
 ## Porcelain
 
-Users may find using Resource Config overly verbose for *Development* and prefer to work with
-the cluster *imperatively* with a shell-like workflow.  Kubectl offers porcelain commands for
-generating and modifying Resources.
+Users may find using resource configuration overly verbose for *development* and prefer to work with
+the cluster *imperatively* with a shell-like workflow. kubectl offers porcelain commands for
+generating and modifying resources.
 
-- Generating + creating Resources such as Deployments, StatefulSets, Services, ConfigMaps, etc
-- Setting fields on Resources
-- Editing (live) Resources in a text editor
+- Generating + creating resources such as Deployments, StatefulSets, Services, ConfigMaps, etc.
+- Setting fields on resources
+- Editing (live) resources in a text editor
 
-{{< alert color="warning" title="Porcelain For Dev Only" >}}
+{{< alert color="warning" title="Porcelain for Dev Only" >}}
 Porcelain commands are time saving for experimenting with workloads in a dev cluster, but shouldn't
 be used for production.
 {{< /alert >}}
-


### PR DESCRIPTION
Inspired from https://github.com/kubernetes/website/pull/46084#discussion_r1585692512, to improve the grammars and provide convenience for localizations.