### PR TITLE
docs: adding description for the kustomize edit command #387

### DIFF
--- a/site/content/en/references/kustomize/cmd/edit/_index.md
+++ b/site/content/en/references/kustomize/cmd/edit/_index.md
@@ -17,4 +17,5 @@ set                       Sets the value of different fields in kustomization fi
 ```
 
 example command:
+
 `kustomize edit add configmap my-configmap --from-file=my-key=file/path --from-literal=my-literal=12345`

--- a/site/content/en/references/kustomize/cmd/edit/_index.md
+++ b/site/content/en/references/kustomize/cmd/edit/_index.md
@@ -6,3 +6,15 @@ weight: 5
 description: >
     Edits a kustomization file
 ---
+
+The `kustomize edit command` provides the ability to manipulate an existing Kustomization configuration. As such, you must have either a valid `kustomization.yaml`, `kustomization.yml` or Kustomization resource already defined in order to use the edit command. The available subcommands include:
+
+```
+add                       Adds an item to the kustomization file
+fix                       Fix the missing fields in kustomization file
+remove                    Removes items from the kustomization file
+set                       Sets the value of different fields in kustomization file
+```
+
+example command:
+`kustomize edit add configmap my-configmap --from-file=my-key=file/path --from-literal=my-literal=12345`


### PR DESCRIPTION
Adds a brief description for the previously blank `kustomize edit` command. 