### PR TITLE
Update _index.md - OCI-based Helm repositories are now supported

### DIFF
--- a/site/content/en/references/kustomize/kustomization/helmcharts/_index.md
+++ b/site/content/en/references/kustomize/kustomization/helmcharts/_index.md
@@ -37,7 +37,6 @@ For enhancements to the helm chart inflation generator feature, we will only sup
 We will not add support for:
 
 - private repository or registry authentication
-- OCI registries
 - other large features that increase the complexity of the feature and/or have significant security implications
 
 ### Future support


### PR DESCRIPTION
OCI-based Helm repositories are now supported in Kustomize.

Ref: https://github.com/kubernetes-sigs/kustomize/pull/5167