### PR TITLE
docs: fix YAML syntax for numeric version tag in kustomization example

### DIFF
--- a/site/content/en/references/kustomize/kustomization/images/_index.md
+++ b/site/content/en/references/kustomize/kustomization/images/_index.md
@@ -64,7 +64,7 @@ images:
   newName: my-registry/my-postgres
   newTag: v1
 - name: nginx
-  newTag: 1.8.0
+  newTag: "1.8.0"
 - name: my-demo-app
   newName: my-app
 - name: alpine


### PR DESCRIPTION
## Summary
Fix YAML syntax error in the kustomization.yaml example by quoting the numeric version tag.

## Changes
- Changed `newTag: 1.8.0` to `newTag: "1.8.0"` in the images section