### PR TITLE
Changes related to documentation

### DIFF
--- a/site/content/en/references/kubectl/auth/_index.md
+++ b/site/content/en/references/kubectl/auth/_index.md
@@ -50,7 +50,7 @@ yes
 ```
 
 ## `reconcile`
-Reconciles rules for RBAC Role, RoleBinding, ClusterRole, and ClusterRole binding objects.
+Reconciles rules for RBAC Role, RoleBinding, ClusterRole, and ClusterRoleBinding objects.
 
 Missing objects are created, and the containing namespace is created for namespaced objects, if required.
 


### PR DESCRIPTION
This PR fixes a minor documentation issue in the kubectl auth reference page:
[](https://kubectl.docs.kubernetes.io/references/kubectl/auth/)

**What Was Incorrect**
The documentation currently uses the wording:
"Reconciles rules for RBAC Role, RoleBinding, ClusterRole, and ClusterRole binding objects."

This includes an incorrect reference to the Kubernetes RBAC resource **ClusterRoleBinding** (written incorrectly as "ClusterRole binding").

**Fix Applied**
Corrected the terminology to use the proper Kubernetes resource name:  "ClusterRoleBinding"

**Updated Version**
"Reconciles rules for RBAC Role, RoleBinding, ClusterRole, and ClusterRoleBinding objects."

close #425 
