### PR TITLE
doc: namespace filter works on namespaces

### DIFF
--- a/site/content/en/references/kustomize/kustomization/namespace/_index.md
+++ b/site/content/en/references/kustomize/kustomization/namespace/_index.md
@@ -8,7 +8,7 @@ description: >
 ---
 
 Will override the existing namespace if it is set on a resource, or add it
-if it is not set on a resource.
+if it is not set on a resource. It also sets the `name` on any namespace resources.
 
 ## Example
 


### PR DESCRIPTION
The namespace hack at https://github.com/kubernetes-sigs/kustomize/blob/master/api/filters/namespace/namespace.go#L93-L106 is a special case

But it is undocumented, this documents it as well.